### PR TITLE
Label sort should be alphabetical and locale-sensitive

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/View/EntriesCardAdapter.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/View/EntriesCardAdapter.java
@@ -51,6 +51,7 @@ import org.shadowice.flocke.andotp.R;
 
 import static org.shadowice.flocke.andotp.Utilities.Settings.SortMode;
 
+import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;

--- a/app/src/main/java/org/shadowice/flocke/andotp/View/EntriesCardAdapter.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/View/EntriesCardAdapter.java
@@ -438,9 +438,16 @@ public class EntriesCardAdapter extends RecyclerView.Adapter<EntryViewHolder>
     }
 
     public class LabelComparator implements Comparator<Entry> {
+        Collator collator;
+
+        LabelComparator(){
+            collator = Collator.getInstance();
+            collator.setStrength(Collator.PRIMARY);
+        }
+
         @Override
         public int compare(Entry o1, Entry o2) {
-            return o1.getLabel().compareTo(o2.getLabel());
+            return collator.compare(o1.getLabel(), o2.getLabel());
         }
     }
 


### PR DESCRIPTION
Doing ascii sort on natural language text will result in unexpected sorting. ie: Lowercase words being sorted after uppercase block or accents messing ordering.

Previous behaviour:
- A
- D
- a
- b

Current behaviour:
- a
- A
- b
- D