### PR TITLE
[#138] Fix exception when saving empty label

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/LetterBitmap.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/LetterBitmap.java
@@ -89,14 +89,18 @@ class LetterBitmap {
      */
     public Bitmap getLetterTile(String displayName, String key, int width, int height) {
         final Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-        char firstChar = displayName.charAt(0);
+        char firstChar = '?';
+
+        if (!displayName.isEmpty()) {
+            firstChar = displayName.charAt(0);
+        }
 
         final Canvas c = mCanvas;
         c.setBitmap(bitmap);
         c.drawColor(pickColor(key));
 
         if (!isEnglishLetterOrDigit(firstChar)) {
-            firstChar = 'A';
+            firstChar = '?';
         }
         mFirstChar[0] = Character.toUpperCase(firstChar);
         mPaint.setTextSize(mTileLetterFontSize);


### PR DESCRIPTION
This fixes #138

But it will permit saving empty labels. Further work will have to be done to prevent saving an empty label (Disable the *Save* button or show a message).

I'm also currently working on another PR where I'm going to refactor the `Entry` a bit so that it will not be possible to have such inconsistent states saved at all.