### PR TITLE
Fixes #190: Changes the import order of gradle repositories.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,7 @@
 
 buildscript {
     repositories {
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
         jcenter()
     }
     dependencies {
@@ -17,7 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
-        maven { url "https://maven.google.com" }
+        google()
         jcenter()
         maven { url "https://jitpack.io" }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.0'
@@ -17,8 +17,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         maven { url "https://maven.google.com" }
+        jcenter()
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
Fetch dependencies from Google's repository first. Prevents a build failure caused by missing artifacts in JCenter.

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all files for configuration ':app:debugCompileClasspath'.
> Could not find common.jar (android.arch.core:common:1.1.0).
  Searched in the following locations:
      https://jcenter.bintray.com/android/arch/core/common/1.1.0/common-1.1.0.jar
```