### PR TITLE
Fixes #71: Use Android's font size settings

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/ThemedActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/ThemedActivity.java
@@ -23,6 +23,7 @@
 package org.shadowice.flocke.andotp.Activities;
 
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -67,9 +68,11 @@ public abstract class ThemedActivity extends AppCompatActivity {
         Locale locale = settings.getLocale();
         Locale.setDefault(locale);
 
-        Configuration config = new Configuration();
+        Resources resources = getBaseContext().getResources();
+        Configuration config = resources.getConfiguration();
         config.locale = locale;
 
-        getBaseContext().getResources().updateConfiguration(config, getBaseContext().getResources().getDisplayMetrics());
+        // TODO: updateConfiguration is marked as deprecated. Replace with android.content.Context.createConfigurationContext
+        resources.updateConfiguration(config, resources.getDisplayMetrics());
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,8 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.0'
@@ -17,8 +15,8 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
-        maven { url "https://maven.google.com" }
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
Updates the existing configuration on a config change instead of overriding
existing settings.

This should fix the issue for now, but still calls the deprecated method `updateConfiguration`.