### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/component_authentication.xml
+++ b/app/src/main/res/layout/component_authentication.xml
@@ -35,7 +35,8 @@
                 android:id="@+id/passwordEdit"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:inputType="textPassword" />
+                android:inputType="textPassword"
+                android:importantForAccessibility="no" />
 
         </android.support.design.widget.TextInputLayout>
 
@@ -44,7 +45,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/settings_hint_password_confirm"
-            android:inputType="textPassword" />
+            android:inputType="textPassword"
+            android:importantForAccessibility="no" />
 
         <TextView
             android:id="@+id/toShortWarning"

--- a/app/src/main/res/layout/component_intro_authentication.xml
+++ b/app/src/main/res/layout/component_intro_authentication.xml
@@ -70,7 +70,8 @@
                     android:id="@+id/introPasswordEdit"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:inputType="textPassword" />
+                    android:inputType="textPassword"
+                    android:importantForAccessibility="no" />
 
             </android.support.design.widget.TextInputLayout>
 
@@ -79,7 +80,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/settings_hint_password_confirm"
-                android:inputType="textPassword" />
+                android:inputType="textPassword"
+                android:importantForAccessibility="no" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/component_password.xml
+++ b/app/src/main/res/layout/component_password.xml
@@ -21,7 +21,8 @@
             android:id="@+id/passwordEdit"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:inputType="textPassword" />
+            android:inputType="textPassword"
+            android:importantForAccessibility="no" />
 
     </android.support.design.widget.TextInputLayout>
 
@@ -30,7 +31,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/settings_hint_password_confirm"
-        android:inputType="textPassword" />
+        android:inputType="textPassword"
+        android:importantForAccessibility="no" />
 
     <android.support.v7.widget.ButtonBarLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/content_authenticate.xml
+++ b/app/src/main/res/layout/content_authenticate.xml
@@ -29,7 +29,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:imeOptions="actionDone"
-            android:inputType="textPassword" />
+            android:inputType="textPassword"
+            android:importantForAccessibility="no" />
 
     </android.support.design.widget.TextInputLayout>
 

--- a/app/src/main/res/layout/dialog_password_entry.xml
+++ b/app/src/main/res/layout/dialog_password_entry.xml
@@ -22,7 +22,8 @@
             android:id="@+id/passwordInput"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:inputType="textPassword" />
+            android:inputType="textPassword"
+            android:importantForAccessibility="no" />
 
     </android.support.design.widget.TextInputLayout>
 
@@ -31,7 +32,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/dialog_label_confirm_password"
-        android:inputType="textPassword" />
+        android:inputType="textPassword"
+        android:importantForAccessibility="no" />
 
     <LinearLayout
         android:orientation="horizontal"


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.