### PR TITLE
Add icon for Hetzner Online

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EntryThumbnail.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EntryThumbnail.java
@@ -79,6 +79,7 @@ public class EntryThumbnail {
         Google(R.drawable.thumb_google),
         HackerOne(R.drawable.thumb_hackerone),
         Heroku(R.drawable.thumb_heroku),
+        Hetzner(R.drawable.thumb_hetzner),
         HMRC(R.drawable.thumb_hmrc),
         HumbleBundle(R.drawable.thumb_humblebundle),
         HurricaneElectric(R.drawable.thumb_hurricane_electric),

--- a/app/src/main/res/drawable/thumb_hetzner.xml
+++ b/app/src/main/res/drawable/thumb_hetzner.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="198dp"
+        android:height="198dp"
+        android:viewportHeight="337"
+        android:viewportWidth="337">
+    <path android:fillColor="#d50c2d"
+          android:pathData="H0V337H337V0z"/>
+    <path android:fillColor="#fff"
+          android:pathData="M287.2,265.7c0,6.9-5.6,12.5-12.5,12.5l-24.8,0c-6.9,0-12.5-5.6-12.5-12.4 l0-72.3H100.2l0,72.3c0,6.9-5.6,12.5-12.5,12.5H62.5c-6.8,0-12.5-5.6-12.5-12.5V73.2c0-6.8,5.6-12.5,12.5-12.5h25.2  c6.8,0,12.5,5.6,12.5,12.5l0,71.5h137.2l0-71.2c0-6.8,5.6-12.5,12.5-12.5h24.8c6.9,0,12.5,5.6,12.5,12.5V265.7z"/>
+</vector>


### PR DESCRIPTION
This PR adds an icon for Hetzner Online GmbH, a german internet hosting company.

The source is here: https://www.hetzner.com/themes/hetzner/images/favicons/safari-pinned-tab.svg
I have splitted the logo in two separate paths in order to have a white foreground instead of transparent.

![Preview](https://user-images.githubusercontent.com/11437439/45032036-f0e1c400-b050-11e8-99da-b97d52450ffb.png)
