### PR TITLE
Made OTP forcfully LTR

### DIFF
--- a/app/src/main/res/layout/component_card.xml
+++ b/app/src/main/res/layout/component_card.xml
@@ -70,6 +70,7 @@
                                 app:srcCompat="@drawable/ic_visibility_visible"/>
 
                             <TextView
+                                android:textDirection="ltr"
                                 android:id="@+id/valueText"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"


### PR DESCRIPTION
In response to #262 I solved the appearance of the OTP in RTL layout by making it LTR forcefully.

I think this problem was very crucial and must be solved ASAP. The app needs more work on RTL support and Persian translation which will be submitted later.