### PR TITLE
ensure the filterstate is correctly applied after onCreate and onRestore

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/MainActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/MainActivity.java
@@ -98,6 +98,7 @@ public class MainActivity extends BaseActivity
     private ListView tagsDrawerListView;
     private TagsAdapter tagsDrawerAdapter;
     private ActionBarDrawerToggle tagsToggle;
+    private String filterString;
 
     // QR code scanning
     private void scanQRCode(){
@@ -283,6 +284,10 @@ public class MainActivity extends BaseActivity
                 ManualEntryDialog.show(MainActivity.this, settings, adapter);
             }
         }
+
+        if (savedInstanceState != null){
+            setFilterString(savedInstanceState.getString("filterString", ""));
+        }
     }
 
     @Override
@@ -319,6 +324,11 @@ public class MainActivity extends BaseActivity
             }
         }
 
+        if (filterString != null) {
+            // ensure the current filter string is applied after a resume
+            setFilterString(this.filterString);
+        }
+
         startUpdater();
     }
 
@@ -326,6 +336,12 @@ public class MainActivity extends BaseActivity
     public void onPause() {
         super.onPause();
         stopUpdater();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString("filterString", filterString);
     }
 
     public void onSharedPreferenceChanged(SharedPreferences prefs, String key) {
@@ -454,11 +470,7 @@ public class MainActivity extends BaseActivity
 
             @Override
             public boolean onQueryTextChange(String newText) {
-                if (newText.isEmpty())
-                    adapter.filterByTags(tagsDrawerAdapter.getActiveTags());
-                else
-                    adapter.getFilter().filter(newText);
-
+                setFilterString(newText);
                 return false;
             }
         });
@@ -488,6 +500,15 @@ public class MainActivity extends BaseActivity
         });
 
         return true;
+    }
+
+    private void setFilterString(String newText) {
+        if (newText.isEmpty())
+            adapter.filterByTags(tagsDrawerAdapter.getActiveTags());
+        else
+            adapter.getFilter().filter(newText);
+
+        this.filterString = newText;
     }
 
     @Override


### PR DESCRIPTION
Currently, if you filter in MainActivity and send the app to the background and restore it again, the filter-string is still displayed, but the list is not filtered:

![image](https://user-images.githubusercontent.com/1370302/56287104-d1009b80-611b-11e9-89a0-89e976ea35fd.png)

This changes stores the last applied filter string in a field and saves it in the app-bundle to ensure its corrctly restored after onCreate and also onResume