### PR TITLE
Instantly generate new code when showing hidden code for HOTP token

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Database/Entry.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Database/Entry.java
@@ -252,6 +252,8 @@ public class Entry {
         return type == OTPType.TOTP || type == OTPType.STEAM;
     }
 
+    public boolean isCounterBased() { return type == OTPType.HOTP; }
+
     public OTPType getType() {
         return type;
     }

--- a/app/src/main/java/org/shadowice/flocke/andotp/View/EntriesCardAdapter.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/View/EntriesCardAdapter.java
@@ -247,6 +247,9 @@ public class EntriesCardAdapter extends RecyclerView.Adapter<EntryViewHolder>
                         });
                         taskHandler.postDelayed(entries.get(realIndex).getHideTask(), settings.getTapToRevealTimeout() * 1000);
 
+                        if (entry.isCounterBased()) {
+                            updateEntry(entry, entries.get(realIndex), position);
+                        }
                         entry.setVisible(true);
                         notifyItemChanged(position);
                     }
@@ -255,18 +258,7 @@ public class EntriesCardAdapter extends RecyclerView.Adapter<EntryViewHolder>
 
             @Override
             public void onCounterClicked(int position) {
-                Entry entry = displayedEntries.get(position);
-                Entry realEntry = entries.get(getRealIndex(position));
-
-                long counter = entry.getCounter() + 1;
-
-                entry.setCounter(counter);
-                entry.updateOTP();
-                notifyItemChanged(position);
-
-                realEntry.setCounter(counter);
-                realEntry.updateOTP();
-                DatabaseHelper.saveDatabase(context, entries, encryptionKey);
+                updateEntry(displayedEntries.get(position), entries.get(getRealIndex(position)), position);
             }
 
             @Override
@@ -276,6 +268,18 @@ public class EntriesCardAdapter extends RecyclerView.Adapter<EntryViewHolder>
         });
 
         return viewHolder;
+    }
+
+    private void updateEntry(Entry entry, Entry realEntry, final int position) {
+        long counter = entry.getCounter() + 1;
+
+        entry.setCounter(counter);
+        entry.updateOTP();
+        notifyItemChanged(position);
+
+        realEntry.setCounter(counter);
+        realEntry.updateOTP();
+        DatabaseHelper.saveDatabase(context, entries, encryptionKey);
     }
 
     private void hideEntry(Entry entry) {


### PR DESCRIPTION
This PR fixes #334. As stated there, it should be possible to generate a new code when the HOTP token is visible - this is the same functionality Google Authenticator provides.

First, I added a new method similar to `isTimeBased()` called `isCounterBased()`. I think it's just nicer than checking for the type. I expected that there's a "counterpart" to `isTimeBased()` so I added it.

Secondly, I refactored the HOTP regenerating code to its own method.

Lastly, in the `onCardClicked` event I check if it's a counter based entry and call the `updateEntry()` method, the same way the counter click event handles it.