### PR TITLE
White navbar in light theme

### DIFF
--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,17 +1,17 @@
 <resources>
     <!-- Light application theme -->
     <style name="AppTheme" parent="AppBaseTheme">
-        <item name="android:navigationBarColor">@android:color/white</item>
+        <item name="android:navigationBarColor">?android:attr/colorBackground</item>
         <item name="android:windowLightNavigationBar">true</item>
     </style>
 
     <style name="AppTheme.Dark" parent="AppBaseTheme.Dark">
-        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:navigationBarColor">?android:attr/colorBackground</item>
         <item name="android:windowLightNavigationBar">false</item>
     </style>
 
     <style name="AppTheme.Black" parent="AppBaseTheme.Black">
-        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:navigationBarColor">?android:attr/colorBackground</item>
         <item name="android:windowLightNavigationBar">false</item>
     </style>
 </resources>

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,0 +1,124 @@
+<resources>
+    <!-- Definitions -->
+    <attr name="windowBackground" format="reference" />
+    <attr name="cardStyle" format="reference" />
+    <attr name="dialogTheme" format="reference" />
+
+    <attr name="colorGithub" format="reference" />
+    <attr name="colorPaypal" format="reference" />
+    <attr name="thumbnailBackground" format="reference" />
+
+    <!-- General styles -->
+    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <style name="Theme.Intro.Solid" parent="Theme.Intro">
+        <item name="android:windowIsTranslucent">false</item>
+    </style>
+
+    <!-- Light application theme -->
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+
+        <item name="windowBackground">?android:attr/colorBackground</item>
+
+        <item name="colorGithub">@color/github_dark</item>
+        <item name="colorPaypal">@color/paypal_dark</item>
+        <item name="thumbnailBackground">@android:color/transparent</item>
+
+        <item name="cardStyle">@style/CardViewStyle</item>
+        <item name="dialogTheme">@style/DialogTheme</item>
+
+        <item name="about_libraries_card">@color/cardview_light_background</item>
+        <item name="about_libraries_title_openSource">@color/about_libraries_text_openSource</item>
+        <item name="about_libraries_text_openSource">@color/about_libraries_text_openSource</item>
+        <item name="about_libraries_dividerDark_openSource">@color/about_libraries_dividerDark_openSource</item>
+        <item name="about_libraries_dividerLight_openSource">@color/about_libraries_dividerLight_openSource</item>
+
+        <item name="android:navigationBarColor">@android:color/white</item>
+        <item name="android:windowLightNavigationBar">true</item>
+    </style>
+
+    <style name="AppTheme.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+
+    </style>
+
+    <style name="CardViewStyle" parent="CardView">
+        <item name="contentPadding">@dimen/activity_margin</item>
+    </style>
+
+    <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog.MinWidth">
+        <item name="colorAccent">@color/colorAccent</item>
+    </style>
+
+    <!-- Dark application theme. -->
+    <style name="AppTheme.Dark" parent="Theme.AppCompat">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+
+        <item name="windowBackground">?android:attr/colorBackground</item>
+        <item name="thumbnailBackground">@color/dark_thumbnail_background</item>
+
+        <item name="colorGithub">@color/github_light</item>
+        <item name="colorPaypal">@color/paypal_light</item>
+
+        <item name="cardStyle">@style/CardViewStyle</item>
+        <item name="dialogTheme">@style/DialogTheme.Dark</item>
+
+        <item name="about_libraries_card">@color/cardview_dark_background</item>
+        <item name="about_libraries_title_openSource">@color/about_libraries_text_openSource_dark</item>
+        <item name="about_libraries_text_openSource">@color/about_libraries_text_openSource_dark</item>
+        <item name="about_libraries_dividerDark_openSource">@color/about_libraries_dividerDark_openSource_dark</item>
+        <item name="about_libraries_dividerLight_openSource">@color/about_libraries_dividerLight_openSource_dark</item>
+
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:windowLightNavigationBar">false</item>
+    </style>
+
+    <style name="AppTheme.Dark.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="DialogTheme.Dark" parent="Theme.AppCompat.Dialog.MinWidth">
+        <item name="colorAccent">@color/colorAccent</item>
+    </style>
+
+    <!-- Black application theme. -->
+    <style name="AppTheme.Black" parent="Theme.AppCompat">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+
+        <item name="windowBackground">@android:color/black</item>
+        <item name="thumbnailBackground">@color/dark_thumbnail_background</item>
+
+        <item name="colorGithub">@color/github_light</item>
+        <item name="colorPaypal">@color/paypal_light</item>
+
+        <item name="cardStyle">@style/CardViewStyle.Black</item>
+        <item name="dialogTheme">@style/DialogTheme.Dark</item>
+
+        <item name="about_libraries_card">@android:color/black</item>
+        <item name="about_libraries_title_openSource">@color/about_libraries_text_openSource_dark</item>
+        <item name="about_libraries_text_openSource">@color/about_libraries_text_openSource_dark</item>
+        <item name="about_libraries_dividerDark_openSource">@color/about_libraries_dividerDark_openSource_dark</item>
+        <item name="about_libraries_dividerLight_openSource">@color/about_libraries_dividerLight_openSource_dark</item>
+
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:windowLightNavigationBar">false</item>
+    </style>
+
+    <style name="CardViewStyle.Black">
+        <item name="cardBackgroundColor">@android:color/black</item>
+    </style>
+
+    <style name="AppTheme.Black.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,124 +1,17 @@
 <resources>
-    <!-- Definitions -->
-    <attr name="windowBackground" format="reference" />
-    <attr name="cardStyle" format="reference" />
-    <attr name="dialogTheme" format="reference" />
-
-    <attr name="colorGithub" format="reference" />
-    <attr name="colorPaypal" format="reference" />
-    <attr name="thumbnailBackground" format="reference" />
-
-    <!-- General styles -->
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
-
-    <style name="Theme.Intro.Solid" parent="Theme.Intro">
-        <item name="android:windowIsTranslucent">false</item>
-    </style>
-
     <!-- Light application theme -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
-
-        <item name="windowBackground">?android:attr/colorBackground</item>
-
-        <item name="colorGithub">@color/github_dark</item>
-        <item name="colorPaypal">@color/paypal_dark</item>
-        <item name="thumbnailBackground">@android:color/transparent</item>
-
-        <item name="cardStyle">@style/CardViewStyle</item>
-        <item name="dialogTheme">@style/DialogTheme</item>
-
-        <item name="about_libraries_card">@color/cardview_light_background</item>
-        <item name="about_libraries_title_openSource">@color/about_libraries_text_openSource</item>
-        <item name="about_libraries_text_openSource">@color/about_libraries_text_openSource</item>
-        <item name="about_libraries_dividerDark_openSource">@color/about_libraries_dividerDark_openSource</item>
-        <item name="about_libraries_dividerLight_openSource">@color/about_libraries_dividerLight_openSource</item>
-
+    <style name="AppTheme" parent="AppBaseTheme">
         <item name="android:navigationBarColor">@android:color/white</item>
         <item name="android:windowLightNavigationBar">true</item>
     </style>
 
-    <style name="AppTheme.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-
-    </style>
-
-    <style name="CardViewStyle" parent="CardView">
-        <item name="contentPadding">@dimen/activity_margin</item>
-    </style>
-
-    <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog.MinWidth">
-        <item name="colorAccent">@color/colorAccent</item>
-    </style>
-
-    <!-- Dark application theme. -->
-    <style name="AppTheme.Dark" parent="Theme.AppCompat">
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
-
-        <item name="windowBackground">?android:attr/colorBackground</item>
-        <item name="thumbnailBackground">@color/dark_thumbnail_background</item>
-
-        <item name="colorGithub">@color/github_light</item>
-        <item name="colorPaypal">@color/paypal_light</item>
-
-        <item name="cardStyle">@style/CardViewStyle</item>
-        <item name="dialogTheme">@style/DialogTheme.Dark</item>
-
-        <item name="about_libraries_card">@color/cardview_dark_background</item>
-        <item name="about_libraries_title_openSource">@color/about_libraries_text_openSource_dark</item>
-        <item name="about_libraries_text_openSource">@color/about_libraries_text_openSource_dark</item>
-        <item name="about_libraries_dividerDark_openSource">@color/about_libraries_dividerDark_openSource_dark</item>
-        <item name="about_libraries_dividerLight_openSource">@color/about_libraries_dividerLight_openSource_dark</item>
-
+    <style name="AppTheme.Dark" parent="AppBaseTheme.Dark">
         <item name="android:navigationBarColor">@android:color/black</item>
         <item name="android:windowLightNavigationBar">false</item>
     </style>
 
-    <style name="AppTheme.Dark.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-    </style>
-
-    <style name="DialogTheme.Dark" parent="Theme.AppCompat.Dialog.MinWidth">
-        <item name="colorAccent">@color/colorAccent</item>
-    </style>
-
-    <!-- Black application theme. -->
-    <style name="AppTheme.Black" parent="Theme.AppCompat">
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
-
-        <item name="windowBackground">@android:color/black</item>
-        <item name="thumbnailBackground">@color/dark_thumbnail_background</item>
-
-        <item name="colorGithub">@color/github_light</item>
-        <item name="colorPaypal">@color/paypal_light</item>
-
-        <item name="cardStyle">@style/CardViewStyle.Black</item>
-        <item name="dialogTheme">@style/DialogTheme.Dark</item>
-
-        <item name="about_libraries_card">@android:color/black</item>
-        <item name="about_libraries_title_openSource">@color/about_libraries_text_openSource_dark</item>
-        <item name="about_libraries_text_openSource">@color/about_libraries_text_openSource_dark</item>
-        <item name="about_libraries_dividerDark_openSource">@color/about_libraries_dividerDark_openSource_dark</item>
-        <item name="about_libraries_dividerLight_openSource">@color/about_libraries_dividerLight_openSource_dark</item>
-
+    <style name="AppTheme.Black" parent="AppBaseTheme.Black">
         <item name="android:navigationBarColor">@android:color/black</item>
         <item name="android:windowLightNavigationBar">false</item>
-    </style>
-
-    <style name="CardViewStyle.Black">
-        <item name="cardBackgroundColor">@android:color/black</item>
-    </style>
-
-    <style name="AppTheme.Black.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,7 +16,7 @@
     </style>
 
     <!-- Light application theme -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
@@ -37,6 +37,8 @@
         <item name="about_libraries_dividerLight_openSource">@color/about_libraries_dividerLight_openSource</item>
     </style>
 
+    <style name="AppTheme" parent="AppBaseTheme"/>
+
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
@@ -51,7 +53,7 @@
     </style>
 
     <!-- Dark application theme. -->
-    <style name="AppTheme.Dark" parent="Theme.AppCompat">
+    <style name="AppBaseTheme.Dark" parent="Theme.AppCompat">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
@@ -72,6 +74,8 @@
         <item name="about_libraries_dividerLight_openSource">@color/about_libraries_dividerLight_openSource_dark</item>
     </style>
 
+    <style name="AppTheme.Dark" parent = "AppBaseTheme.Dark"/>
+
     <style name="AppTheme.Dark.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
@@ -82,7 +86,7 @@
     </style>
 
     <!-- Black application theme. -->
-    <style name="AppTheme.Black" parent="Theme.AppCompat">
+    <style name="AppBaseTheme.Black" parent="Theme.AppCompat">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
@@ -102,6 +106,8 @@
         <item name="about_libraries_dividerDark_openSource">@color/about_libraries_dividerDark_openSource_dark</item>
         <item name="about_libraries_dividerLight_openSource">@color/about_libraries_dividerLight_openSource_dark</item>
     </style>
+
+    <style name="AppTheme.Black" parent="AppBaseTheme.Black"/>
 
     <style name="CardViewStyle.Black">
         <item name="cardBackgroundColor">@android:color/black</item>


### PR DESCRIPTION
I'd really like it if the light theme used a white system navbar. 
Comparison below.

![andOTP](https://user-images.githubusercontent.com/12488186/62333192-d97fb500-b505-11e9-938f-860ba84ffa6a.jpg)

The main purpose is to mitigate burn-in on OLED screen phones.
Personally, the phones I have owned with OLED screens have had significant burn-in around the system navbar after a year.

The original black system navbar is still used in dark and black themes for those who want the option.

What I did is created a "values-v27" folder and a "styles.xml".
In each theme I added the two items:
```
<item name="android:navigationBarColor"></item>
<item name="android:windowLightNavigationBar"></item>
```

Feedback and input is appreciated.