### PR TITLE
Add automatic icon mapping if issuer is provided

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Database/Entry.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Database/Entry.java
@@ -88,6 +88,7 @@ public class Entry {
         this.label = label;
         this.algorithm = algorithm;
         this.tags = tags;
+        setThumbnailFromIssuer(issuer);
     }
 
     public Entry(OTPType type, String secret, long counter, int digits, String issuer, String label, TokenCalculator.HashAlgorithm algorithm, List<String> tags) {
@@ -99,6 +100,7 @@ public class Entry {
         this.label = label;
         this.algorithm = algorithm;
         this.tags = tags;
+        setThumbnailFromIssuer(issuer);
     }
 
     public Entry(String contents) throws Exception {
@@ -158,10 +160,14 @@ public class Entry {
             this.algorithm = TokenCalculator.DEFAULT_ALGORITHM;
         }
 
-        if(tags != null) {
+        if (tags != null) {
             this.tags = tags;
         } else {
             this.tags = new ArrayList<>();
+        }
+
+        if (issuer != null) {
+            setThumbnailFromIssuer(issuer);
         }
     }
 
@@ -387,6 +393,14 @@ public class Entry {
             return true;
         } else {
             return false;
+        }
+    }
+
+    private void setThumbnailFromIssuer(String issuer) {
+        try {
+            this.thumbnail = EntryThumbnail.EntryThumbnails.valueOfIgnoreCase(issuer);
+        } catch(Exception e) {
+            this.thumbnail = EntryThumbnail.EntryThumbnails.Default;
         }
     }
 

--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EntryThumbnail.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EntryThumbnail.java
@@ -234,6 +234,12 @@ public class EntryThumbnail {
         public AssetType getAssetType() {
             return assetType;
         }
+
+        public static EntryThumbnails valueOfIgnoreCase(String thumbnail) {
+            for (EntryThumbnails entryThumbnails : values())
+                if (entryThumbnails.name().equalsIgnoreCase(thumbnail)) return entryThumbnails;
+                throw new IllegalArgumentException();
+        }
     }
 
     public static Bitmap getThumbnailGraphic(Context context, String label, int size, EntryThumbnails thumbnail) {

--- a/app/src/main/java/org/shadowice/flocke/andotp/View/EntriesCardAdapter.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/View/EntriesCardAdapter.java
@@ -371,6 +371,51 @@ public class EntriesCardAdapter extends RecyclerView.Adapter<EntryViewHolder>
         return true;
     }
 
+    public void editEntryIssuer(final int pos) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+
+        int marginSmall = context.getResources().getDimensionPixelSize(R.dimen.activity_margin_small);
+        int marginMedium = context.getResources().getDimensionPixelSize(R.dimen.activity_margin_medium);
+
+        final EditText input = new EditText(context);
+        input.setLayoutParams(new  FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+        input.setText(displayedEntries.get(pos).getIssuer());
+        input.setSingleLine();
+
+        FrameLayout container = new FrameLayout(context);
+        container.setPaddingRelative(marginMedium, marginSmall, marginMedium, 0);
+        container.addView(input);
+
+        builder.setTitle(R.string.dialog_title_rename)
+                .setView(container)
+                .setPositiveButton(R.string.button_save, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        int realIndex = getRealIndex(pos);
+                        String newIssuer = input.getEditableText().toString();
+
+                        displayedEntries.get(pos).setIssuer(newIssuer);
+                        if (sortMode == SortMode.LABEL) {
+                            displayedEntries = sortEntries(displayedEntries);
+                            notifyDataSetChanged();
+                        } else {
+                            notifyItemChanged(pos);
+                        }
+
+                        Entry e = entries.get(realIndex);
+                        e.setIssuer(newIssuer);
+
+                        DatabaseHelper.saveDatabase(context, entries, encryptionKey);
+                    }
+                })
+                .setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {}
+                })
+                .create()
+                .show();
+    }
+
     public void editEntryLabel(final int pos) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
 
@@ -585,7 +630,10 @@ public class EntriesCardAdapter extends RecyclerView.Adapter<EntryViewHolder>
             public boolean onMenuItemClick(MenuItem item) {
                 int id = item.getItemId();
 
-                if (id == R.id.menu_popup_editLabel) {
+                if (id == R.id.menu_popup_editIssuer) {
+                    editEntryIssuer(pos);
+                    return true;
+                } else if (id == R.id.menu_popup_editLabel) {
                     editEntryLabel(pos);
                     return true;
                 } else if(id == R.id.menu_popup_changeImage) {

--- a/app/src/main/java/org/shadowice/flocke/andotp/View/EntryViewHolder.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/View/EntryViewHolder.java
@@ -64,6 +64,7 @@ public class EntryViewHolder extends RecyclerView.ViewHolder
     private ImageView visibleImg;
     private ImageView thumbnailImg;
     private TextView value;
+    private TextView issuer;
     private TextView label;
     private TextView counter;
     private TextView tags;
@@ -81,6 +82,7 @@ public class EntryViewHolder extends RecyclerView.ViewHolder
         thumbnailFrame = v.findViewById(R.id.thumbnailFrame);
         thumbnailImg = v.findViewById(R.id.thumbnailImg);
         coverLayout = v.findViewById(R.id.coverLayout);
+        issuer = v.findViewById(R.id.textViewIssuer);
         label = v.findViewById(R.id.textViewLabel);
         tags = v.findViewById(R.id.textViewTags);
         counterLayout = v.findViewById(R.id.counterLayout);
@@ -148,6 +150,14 @@ public class EntryViewHolder extends RecyclerView.ViewHolder
         }
 
         final String tokenFormatted = Tools.formatToken(entry.getCurrentOTP(), settings.getTokenSplitGroupSize());
+
+        String issuerText = entry.getIssuer();
+        if (!TextUtils.isEmpty(issuerText)) {
+            issuer.setText(entry.getIssuer());
+            issuer.setVisibility(View.VISIBLE);
+        } else {
+            issuer.setVisibility(View.GONE);
+        }
 
         label.setText(entry.getLabel());
         value.setText(tokenFormatted);

--- a/app/src/main/java/org/shadowice/flocke/andotp/View/ManualEntryDialog.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/View/ManualEntryDialog.java
@@ -59,6 +59,7 @@ public class ManualEntryDialog {
         View inputView = callingActivity.getLayoutInflater().inflate(R.layout.dialog_manual_entry, container, false);
 
         final Spinner typeInput = inputView.findViewById(R.id.manual_type);
+        final EditText issuerInput = inputView.findViewById(R.id.manual_issuer);
         final EditText labelInput = inputView.findViewById(R.id.manual_label);
         final EditText secretInput = inputView.findViewById(R.id.manual_secret);
         final EditText counterInput = inputView.findViewById(R.id.manual_counter);
@@ -192,6 +193,7 @@ public class ManualEntryDialog {
                         Entry.OTPType type = (Entry.OTPType) typeInput.getSelectedItem();
                         TokenCalculator.HashAlgorithm algorithm = (TokenCalculator.HashAlgorithm) algorithmInput.getSelectedItem();
 
+                        String issuer = issuerInput.getText().toString();
                         String label = labelInput.getText().toString();
                         String secret = secretInput.getText().toString();
                         int digits = Integer.parseInt(digitsInput.getText().toString());
@@ -199,7 +201,7 @@ public class ManualEntryDialog {
                         if (type == Entry.OTPType.TOTP || type == Entry.OTPType.STEAM) {
                             int period = Integer.parseInt(periodInput.getText().toString());
 
-                            Entry e = new Entry(type, secret, period, digits, label, algorithm, tagsAdapter.getActiveTags());
+                            Entry e = new Entry(type, secret, period, digits, issuer, label, algorithm, tagsAdapter.getActiveTags());
                             e.updateOTP();
                             e.setLastUsed(System.currentTimeMillis());
                             adapter.addEntry(e);
@@ -209,7 +211,7 @@ public class ManualEntryDialog {
                         } else if (type == Entry.OTPType.HOTP) {
                             long counter = Long.parseLong(counterInput.getText().toString());
 
-                            Entry e = new Entry(type, secret, counter, digits, label, algorithm, tagsAdapter.getActiveTags());
+                            Entry e = new Entry(type, secret, counter, digits, issuer, label, algorithm, tagsAdapter.getActiveTags());
                             e.updateOTP();
                             e.setLastUsed(System.currentTimeMillis());
                             adapter.addEntry(e);

--- a/app/src/main/res/layout/component_card.xml
+++ b/app/src/main/res/layout/component_card.xml
@@ -106,6 +106,15 @@
                     </LinearLayout>
 
                     <TextView
+                        android:id="@+id/textViewIssuer"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:maxLines="1"
+                        android:ellipsize="end"
+                        android:textSize="18sp"
+                        android:textStyle="bold" />
+
+                    <TextView
                         android:id="@+id/textViewLabel"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_manual_entry.xml
+++ b/app/src/main/res/layout/dialog_manual_entry.xml
@@ -42,6 +42,27 @@
                 android:layout_weight="3"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:text="@string/label_issuer"/>
+
+            <EditText
+                android:id="@+id/manual_issuer"
+                android:layout_weight="7"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:hint="@string/label_issuer"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal" >
+
+            <TextView
+                android:layout_weight="3"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
                 android:text="@string/label_label"/>
 
             <EditText

--- a/app/src/main/res/menu/menu_popup.xml
+++ b/app/src/main/res/menu/menu_popup.xml
@@ -2,6 +2,9 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
+        android:id="@+id/menu_popup_editIssuer"
+        android:title="@string/menu_popup_edit_issuer" />
+    <item
         android:id="@+id/menu_popup_editLabel"
         android:title="@string/menu_popup_edit_label" />
 

--- a/app/src/main/res/values/strings_main.xml
+++ b/app/src/main/res/values/strings_main.xml
@@ -26,6 +26,7 @@
     <string name="label_period">Period</string>
     <string name="label_digits">Digits</string>
     <string name="label_counter">Counter</string>
+    <string name="label_issuer">Issuer</string>
     <string name="label_label">Label</string>
     <string name="label_algorithm">Algorithm</string>
     <string name="label_tags">Tags</string>
@@ -47,6 +48,7 @@
     <string name="menu_sort_label">Label</string>
     <string name="menu_sort_last_used">Last used</string>
 
+    <string name="menu_popup_edit_issuer">Edit issuer</string>
     <string name="menu_popup_edit_label">Edit label</string>
     <string name="menu_popup_change_image">Change image</string>
     <string name="menu_popup_edit_tags">Edit tags</string>


### PR DESCRIPTION
Fixes #388 based on changes provided by #372.

Both manual and QR code based addition of entries will check available icons for provided issuer.
If not null or matching (case insensitive) it will add the icon to the entry. Fallback to Default thumbnail still exists.