### PR TITLE
Workaround: Hide otp card on screen off (#264)

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/MainActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/MainActivity.java
@@ -329,8 +329,11 @@ public class MainActivity extends BaseActivity
             // ensure the current filter string is applied after a resume
             setFilterString(this.filterString);
         }
-        if(settings.getAuthMethod() == AuthMethod.DEVICE)
-            findViewById(R.id.cardList).setVisibility(View.VISIBLE);
+
+        View cardList = findViewById(R.id.cardList);
+        if(cardList.getVisibility() == View.INVISIBLE)
+            cardList.setVisibility(View.VISIBLE);
+
         startUpdater();
     }
 

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/MainActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/MainActivity.java
@@ -329,12 +329,20 @@ public class MainActivity extends BaseActivity
             // ensure the current filter string is applied after a resume
             setFilterString(this.filterString);
         }
-
+        if(settings.getAuthMethod() == AuthMethod.DEVICE)
+            findViewById(R.id.cardList).setVisibility(View.VISIBLE);
         startUpdater();
     }
 
     @Override
     public void onPause() {
+        if(settings.getAuthMethod() == AuthMethod.DEVICE)
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    findViewById(R.id.cardList).setVisibility(View.INVISIBLE);
+                }
+            });
         super.onPause();
         stopUpdater();
     }


### PR DESCRIPTION
This is a potential workaround for #264.
In this commit the OTP CardList (and with this, it's children) gets hidden when the AuthMethod is set to Device Credentials and the Activity gets paused. On resume the CardList will be made visible again if it's not, regardless of AuthMethod to prevent the CardList staying invisible when changing to other AuthMethods.

Turning the CardList invisible is run on the UI thread so the change is made before the UI Queue stops. If we don't do this, the change is not made when the screen is turned off while the Activity is active. E.g. on time-out or turning the screen of by using the power button the change would not be made in time.