### PR TITLE
Implemented intent-filter to receive otpauth requests

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="otpauth" android:host="totp" />
+                <data android:scheme="otpauth" android:host="hotp" />
+            </intent-filter>
+            <intent-filter>
                 <action android:name="org.shadowice.flocke.andotp.intent.SCAN_QR" />
                 <action android:name="org.shadowice.flocke.andotp.intent.ENTER_DETAILS" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/MainActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/MainActivity.java
@@ -277,17 +277,32 @@ public class MainActivity extends BaseActivity
 
         setupDrawer();
 
+        checkIntent();
+
+        if (savedInstanceState != null){
+            setFilterString(savedInstanceState.getString("filterString", ""));
+        }
+    }
+
+    private void checkIntent() {
         Intent callingIntent = getIntent();
         if (callingIntent != null && callingIntent.getAction() != null) {
             if (callingIntent.getAction().equals(INTENT_SCAN_QR)) {
                 scanQRCode();
             } else if (callingIntent.getAction().equals(INTENT_ENTER_DETAILS)) {
                 ManualEntryDialog.show(MainActivity.this, settings, adapter);
+            } else if (callingIntent.getAction().equals(Intent.ACTION_VIEW) && !requireAuthentication) {
+                try {
+                    Entry entry = new Entry(getIntent().getDataString());
+                    entry.updateOTP();
+                    entry.setLastUsed(System.currentTimeMillis());
+                    adapter.addEntry(entry);
+                    adapter.saveEntries();
+                    Toast.makeText(this, R.string.toast_intent_creation_succeeded, Toast.LENGTH_LONG).show();
+                } catch (Exception e) {
+                    Toast.makeText(this, R.string.toast_intent_creation_failed, Toast.LENGTH_LONG).show();
+                }
             }
-        }
-
-        if (savedInstanceState != null){
-            setFilterString(savedInstanceState.getString("filterString", ""));
         }
     }
 
@@ -321,6 +336,7 @@ public class MainActivity extends BaseActivity
                     updateEncryption(null);
                 } else {
                     populateAdapter();
+                    checkIntent();
                 }
             }
         }

--- a/app/src/main/res/values/strings_main.xml
+++ b/app/src/main/res/values/strings_main.xml
@@ -10,7 +10,7 @@
     <string name="button_settings">Settings</string>
     <string name="button_all_tags">All tags</string>
     <string name="button_no_tags">No tags</string>
-    
+
     <!-- Custom formatting -->
     <string name="format_custom_period">%d s</string>
 
@@ -59,6 +59,8 @@
     <string name="toast_entry_exists">This entry already exists</string>
     <string name="toast_invalid_qr_code">Invalid QR Code</string>
     <string name="toast_encryption_key_empty">Encryption key not loaded</string>
+    <string name="toast_intent_creation_failed">Invalid intent-provided code</string>
+    <string name="toast_intent_creation_succeeded">Intent-provided code added</string>
 
     <!-- Dialogs -->
     <string name="dialog_title_auth">Authenticate</string>


### PR DESCRIPTION
Even if I didn't have any problems in the past with adding a new 2FA entry, now andOTP acts as receiver for `otpauth` links/data. This PR follows the discussion in  #324.

This is based on current master, so automatic tumbnail mapping and the split into separate issuer is not presented in the demo gif 👇

![andOTP](https://user-images.githubusercontent.com/9077622/66109299-a2408980-e5c4-11e9-976d-2cc89a34b527.gif)
