### PR TITLE
Fixed black navigation bar for OxygenOS devices #408

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/ThemedActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/ThemedActivity.java
@@ -24,10 +24,13 @@ package org.shadowice.flocke.andotp.Activities;
 
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
+import org.shadowice.flocke.andotp.R;
 import org.shadowice.flocke.andotp.Utilities.Settings;
+import org.shadowice.flocke.andotp.Utilities.Tools;
 
 import java.util.Locale;
 
@@ -40,6 +43,11 @@ public abstract class ThemedActivity extends AppCompatActivity {
 
         setTheme(settings.getTheme());
         setLocale();
+
+        //Set navigation bar color
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            getWindow().setNavigationBarColor(Tools.getThemeColor(this,R.attr.navigationBarColor));
+        }
 
         super.onCreate(savedInstanceState);
     }

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,17 +1,14 @@
 <resources>
     <!-- Light application theme -->
     <style name="AppTheme" parent="AppBaseTheme">
-        <item name="android:navigationBarColor">?android:attr/colorBackground</item>
         <item name="android:windowLightNavigationBar">true</item>
     </style>
 
     <style name="AppTheme.Dark" parent="AppBaseTheme.Dark">
-        <item name="android:navigationBarColor">?android:attr/colorBackground</item>
         <item name="android:windowLightNavigationBar">false</item>
     </style>
 
     <style name="AppTheme.Black" parent="AppBaseTheme.Black">
-        <item name="android:navigationBarColor">@color/black</item>
         <item name="android:windowLightNavigationBar">false</item>
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,6 +7,8 @@
     <attr name="colorGithub" format="reference" />
     <attr name="thumbnailBackground" format="reference" />
 
+    <attr name="navigationBarColor" format="reference" />
+
     <!-- General styles -->
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
 
@@ -21,6 +23,7 @@
         <item name="colorAccent">@color/colorAccent</item>
 
         <item name="windowBackground">?android:attr/colorBackground</item>
+        <item name="navigationBarColor">?android:attr/colorBackground</item>
 
         <item name="colorGithub">@color/github_dark</item>
         <item name="thumbnailBackground">@android:color/transparent</item>
@@ -57,6 +60,7 @@
         <item name="colorAccent">@color/colorAccent</item>
 
         <item name="windowBackground">?android:attr/colorBackground</item>
+        <item name="navigationBarColor">?android:attr/colorBackground</item>
         <item name="thumbnailBackground">@color/dark_thumbnail_background</item>
 
         <item name="colorGithub">@color/github_light</item>
@@ -89,6 +93,7 @@
         <item name="colorAccent">@color/colorAccent</item>
 
         <item name="windowBackground">@color/black</item>
+        <item name="navigationBarColor">@color/black</item>
         <item name="thumbnailBackground">@color/dark_thumbnail_background</item>
 
         <item name="colorGithub">@color/github_light</item>


### PR DESCRIPTION
Oxygen OS doesn't respect android:navigationBarColor if it's set to black in xml. This is to prevent burn in on the screen. More information can be found [here](https://forums.oneplus.com/threads/cannot-set-navigation-bar-color-to-pure-black-ff000000-via-values-xml.908719/)

A workaround would be to set the navigation bar color programmatically using [setNavigationBarColor()](https://developer.android.com/reference/android/view/Window.html#setNavigationBarColor(int))

I've implemented this workaround and tested on Pixel 3 in emulator and on my OnePlus 7 Pro