### PR TITLE
dialog_manual_entry.xml: do not use auto-completion for secret

### DIFF
--- a/app/src/main/res/layout/dialog_manual_entry.xml
+++ b/app/src/main/res/layout/dialog_manual_entry.xml
@@ -92,6 +92,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:lines="3"
+                android:inputType="textVisiblePassword"
                 android:hint="@string/hint_secret" />
 
         </LinearLayout>


### PR DESCRIPTION
When manually entering details, the secret is currently visible and completed by the keyboard. This may occur learning of the secret by the keyboard. In order to prevent this, use inputType "textVisiblePassword". This keeps the secret visible but disables auto-completion.