### PR TITLE
Added transparency to the card if it's selected to be reordered in the list

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/View/EntryViewHolder.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/View/EntryViewHolder.java
@@ -280,12 +280,14 @@ public class EntryViewHolder extends RecyclerView.ViewHolder
     public void onItemSelected() {
         if (callback != null)
             callback.onMoveEventStart();
+        card.setAlpha(0.5f);
     }
 
     @Override
     public void onItemClear() {
         if (callback != null)
             callback.onMoveEventStop();
+        card.setAlpha(1f);
     }
 
     public void setCallback(Callback cb) {


### PR DESCRIPTION
Implemented #487 
 
Added simple transparency setting in onItemSelected() (sets transparency to 0.5f) and in onItemClear() (sets transparency to 0.5f)

Tested on my OnePlus 7 Pro and for both light and dark themes.