### PR TITLE
Add weclapp icon

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EntryThumbnail.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EntryThumbnail.java
@@ -276,6 +276,7 @@ public class EntryThumbnail {
         Wallet(R.drawable.thumb_wallet),
         Wargaming(R.drawable.thumb_wargaming),
         Wasabi(R.drawable.thumb_wasabi),
+        Weclapp(R.drawable.thumb_weclapp),
         WebDe(R.drawable.thumb_web_de),
         Wikimedia(R.drawable.thumb_wikimedia),
         Wordpress(R.drawable.thumb_wordpress),

--- a/app/src/main/res/drawable/thumb_weclapp.xml
+++ b/app/src/main/res/drawable/thumb_weclapp.xml
@@ -1,0 +1,24 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="670.6535dp"
+    android:height="563.8368dp"
+    android:viewportWidth="670.6535"
+    android:viewportHeight="563.8368">
+  <path
+      android:pathData="m184.691,58.409 l-48.289,323.073c-7.901,49.812 -80.607,48.7 -86.88,-0L1.232,58.409c-6.672,-29.804 14.601,-58.409 43.44,-58.409L141.251,-0C170.088,-0 191.363,28.605 184.691,58.409"
+      android:fillColor="#43b183"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"
+      android:fillAlpha="1"/>
+  <path
+      android:pathData="m669.422,58.409 l-48.291,323.073c-7.9,49.812 -80.605,48.7 -86.879,-0L485.962,58.409c-6.672,-29.804 14.603,-58.409 43.44,-58.409L625.982,-0C654.819,-0 676.094,28.605 669.422,58.409"
+      android:fillColor="#43b183"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"
+      android:fillAlpha="1"/>
+  <path
+      android:pathData="m243.597,505.427 l48.291,-323.073c7.9,-49.812 80.605,-48.701 86.879,-0L427.055,505.427c6.673,29.804 -14.601,58.409 -43.439,58.409L287.037,563.837C258.199,563.837 236.925,535.231 243.597,505.427"
+      android:fillColor="#43b183"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"
+      android:fillAlpha="1"/>
+</vector>

--- a/app/src/main/res/drawable/thumb_weclapp.xml
+++ b/app/src/main/res/drawable/thumb_weclapp.xml
@@ -1,24 +1,15 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="670.6535dp"
-    android:height="563.8368dp"
-    android:viewportWidth="670.6535"
-    android:viewportHeight="563.8368">
-  <path
-      android:pathData="m184.691,58.409 l-48.289,323.073c-7.901,49.812 -80.607,48.7 -86.88,-0L1.232,58.409c-6.672,-29.804 14.601,-58.409 43.44,-58.409L141.251,-0C170.088,-0 191.363,28.605 184.691,58.409"
-      android:fillColor="#43b183"
-      android:strokeColor="#00000000"
-      android:fillType="nonZero"
-      android:fillAlpha="1"/>
-  <path
-      android:pathData="m669.422,58.409 l-48.291,323.073c-7.9,49.812 -80.605,48.7 -86.879,-0L485.962,58.409c-6.672,-29.804 14.603,-58.409 43.44,-58.409L625.982,-0C654.819,-0 676.094,28.605 669.422,58.409"
-      android:fillColor="#43b183"
-      android:strokeColor="#00000000"
-      android:fillType="nonZero"
-      android:fillAlpha="1"/>
-  <path
-      android:pathData="m243.597,505.427 l48.291,-323.073c7.9,-49.812 80.605,-48.701 86.879,-0L427.055,505.427c6.673,29.804 -14.601,58.409 -43.439,58.409L287.037,563.837C258.199,563.837 236.925,535.231 243.597,505.427"
-      android:fillColor="#43b183"
-      android:strokeColor="#00000000"
-      android:fillType="nonZero"
-      android:fillAlpha="1"/>
+    android:width="127.99999dp"
+    android:height="107.61286dp"
+    android:viewportWidth="127.99999"
+    android:viewportHeight="107.61286">
+    <path
+        android:fillColor="#43b183"
+        android:pathData="m35.25,11.148 l-9.216,61.661c-1.508,9.507 -15.384,9.295 -16.582,-0L0.235,11.148c-1.273,-5.688 2.787,-11.148 8.291,-11.148L26.959,0C32.463,0 36.523,5.46 35.25,11.148" />
+    <path
+        android:fillColor="#43b183"
+        android:pathData="m127.765,11.148 l-9.217,61.661c-1.508,9.507 -15.384,9.295 -16.581,-0L92.75,11.148c-1.273,-5.688 2.787,-11.148 8.291,-11.148L119.474,0C124.978,0 129.038,5.46 127.765,11.148" />
+    <path
+        android:fillColor="#43b183"
+        android:pathData="m46.493,96.465 l9.217,-61.661c1.508,-9.507 15.384,-9.295 16.581,-0L81.507,96.465c1.274,5.688 -2.787,11.148 -8.291,11.148L54.783,107.613C49.28,107.613 45.219,102.153 46.493,96.465" />
 </vector>


### PR DESCRIPTION
Add icon for [weclapp](https://www.weclapp.com), extracted from here: https://www.weclapp.com/wp-content/uploads/2019/08/weclapp-presskit.zip
@ertanoe Do you approve this usage of the artwork?

![andotp-icon-weclapp](https://user-images.githubusercontent.com/16167751/83351978-a33edc00-a348-11ea-9f03-843f84e4922f.png)