### PR TITLE
Add android sync to initial flow

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/SettingsActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/SettingsActivity.java
@@ -40,6 +40,7 @@ import android.preference.PreferenceManager;
 import androidx.appcompat.widget.Toolbar;
 
 import android.provider.DocumentsContract;
+import android.util.Log;
 import android.view.ViewStub;
 import android.widget.Toast;
 
@@ -166,6 +167,13 @@ public class SettingsActivity extends BaseActivity
                 if (fragment.useAndroidSync != null)
                     fragment.useAndroidSync.setEnabled(true);
             }
+        } else if(key.equals(getString(R.string.settings_key_enable_android_backup_service)))
+        {
+            Log.d(SettingsActivity.class.getSimpleName(), "onSharedPreferenceChanged called modifying settings_key_enable_android_backup_service service is now: " +
+                    (settings.getAndroidBackupServiceEnabled() ? "enabled" : "disabled"));
+
+            int message = settings.getAndroidBackupServiceEnabled() ? R.string.settings_toast_android_sync_enabled : R.string.settings_toast_android_sync_disabled;
+            Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
         }
 
         fragment.updateAutoBackup();

--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/BackupAgent.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/BackupAgent.java
@@ -29,6 +29,8 @@ import android.app.backup.BackupDataOutput;
 import android.app.backup.FileBackupHelper;
 import android.app.backup.SharedPreferencesBackupHelper;
 import android.os.ParcelFileDescriptor;
+import android.util.Log;
+
 
 import java.io.IOException;
 
@@ -44,19 +46,29 @@ public class BackupAgent extends BackupAgentHelper {
     @Override
     public void onBackup(ParcelFileDescriptor oldState, BackupDataOutput data, ParcelFileDescriptor newState) throws IOException {
         Settings settings = new Settings(this);
+        StringBuilder stringBuilder = new StringBuilder("onBackup called with the backup service set to ");
+        stringBuilder.append(settings.getAndroidBackupServiceEnabled() ? "enabled" : "disabled");
 
         if(settings.getAndroidBackupServiceEnabled()) {
             synchronized (DatabaseHelper.DatabaseFileLock) {
+                stringBuilder.append(" calling parent onBackup");
                 super.onBackup(oldState, data, newState);
             }
         }
+        Log.d(BackupAgent.class.getSimpleName(), stringBuilder.toString());
     }
 
     @Override
     public void onRestore(BackupDataInput data, int appVersionCode, ParcelFileDescriptor newState) throws IOException {
+        Settings settings = new Settings(this);
+        StringBuilder stringBuilder = new StringBuilder("onRestore called with the backup service set to ");
+        stringBuilder.append(settings.getAndroidBackupServiceEnabled() ? "enabled" : "disabled");
+
         synchronized (DatabaseHelper.DatabaseFileLock) {
+            stringBuilder.append(" but restore happens regardless, calling parent onRestore");
             super.onRestore(data, appVersionCode, newState);
         }
+        Log.d(BackupAgent.class.getSimpleName(), stringBuilder.toString());
     }
 
     @Override

--- a/app/src/main/res/layout/component_intro_android_sync.xml
+++ b/app/src/main/res/layout/component_intro_android_sync.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clipToPadding="false">
+
+    <LinearLayout
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="top"
+    android:gravity="top"
+    android:padding="@dimen/activity_margin_large" >
+
+        <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+        android:textStyle="bold"
+        android:text="@string/settings_title_enable_android_backup_service" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/activity_margin"
+            android:text="@string/intro_slide_android_backup_desc"/>
+
+        <Switch
+            android:id="@+id/introAndroidSync"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/activity_margin"
+            android:checked="true"
+            android:text="@string/settings_toast_android_sync_enabled" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/values/strings_intro.xml
+++ b/app/src/main/res/values/strings_intro.xml
@@ -38,4 +38,5 @@
     <string name="intro_slide4_title">Finished</string>
     <string name="intro_slide4_desc">Your settings have been saved, you are now all set to use
         <b>andOTP</b>!</string>
+    <string name="intro_slide_android_backup_desc">Android sync is a feature built in to android used to back up app data to a 3rd party service (usually Google). Backups are always encrypted and unaccessible to 3rd parties without your master password. Requires use of Password encryption method.</string>
 </resources>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -134,6 +134,9 @@
     <string name="settings_toast_auth_upgrade_failed">Failed to silently upgrade your password / PIN
         to the new encryption, please manually reset it in the Settings!</string>
 
+    <string name="settings_toast_android_sync_enabled">Android sync enabled</string>
+    <string name="settings_toast_android_sync_disabled">Android sync disabled</string>
+
     <string name="settings_dialog_title_warning">Warning</string>
     <string name="settings_dialog_title_error">Error</string>
     <string name="settings_dialog_title_clear_keystore">Clear the KeyStore?</string>


### PR DESCRIPTION
Fix #620 

Adds an option to disable android sync to the initial flow
![device-2020-08-11-084826](https://user-images.githubusercontent.com/5472275/89873315-23d45100-dbb2-11ea-9535-7d748fa01124.png)
