### PR TITLE
#639 Shared Preference NPE Fix

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/MainActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/MainActivity.java
@@ -888,4 +888,10 @@ public class MainActivity extends BaseActivity
 
         return super.onKeyDown(keyCode, event);
     }
+
+    @Override
+    protected void onDestroy() {
+        settings.unregisterPreferenceChangeListener(this);
+        super.onDestroy();
+    }
 }

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/SettingsActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/SettingsActivity.java
@@ -66,10 +66,12 @@ import static org.shadowice.flocke.andotp.Utilities.Constants.EncryptionType;
 
 public class SettingsActivity extends BaseActivity
         implements SharedPreferences.OnSharedPreferenceChangeListener{
-    SettingsFragment fragment;
 
-    SecretKey encryptionKey = null;
-    boolean encryptionChanged = false;
+    private SettingsFragment fragment;
+    private SharedPreferences prefs;
+
+    private SecretKey encryptionKey = null;
+    private boolean encryptionChanged = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -104,8 +106,8 @@ public class SettingsActivity extends BaseActivity
                 .replace(R.id.container_content, fragment)
                 .commit();
 
-        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(this);
-        sharedPref.registerOnSharedPreferenceChangeListener(this);
+        prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        prefs.registerOnSharedPreferenceChangeListener(this);
     }
 
     @Override
@@ -277,18 +279,26 @@ public class SettingsActivity extends BaseActivity
         }
     }
 
+    @Override
+    protected void onDestroy() {
+        prefs.unregisterOnSharedPreferenceChangeListener(this);
+        prefs = null;
+
+        super.onDestroy();
+    }
+
     public static class SettingsFragment extends PreferenceFragment {
-        PreferenceCategory catSecurity;
+        private PreferenceCategory catSecurity;
 
-        Settings settings;
-        ListPreference encryption;
-        Preference backupLocation;
-        ListPreference useAutoBackup;
-        CheckBoxPreference useAndroidSync;
+        private Settings settings;
+        private ListPreference encryption;
+        private Preference backupLocation;
+        private ListPreference useAutoBackup;
+        private CheckBoxPreference useAndroidSync;
 
-        OpenPgpAppPreference pgpProvider;
-        EditTextPreference pgpEncryptionKey;
-        OpenPgpKeyPreference pgpSigningKey;
+        private OpenPgpAppPreference pgpProvider;
+        private EditTextPreference pgpEncryptionKey;
+        private OpenPgpKeyPreference pgpSigningKey;
 
         public void encryptionChangeWithDialog(final EncryptionType encryptionType) {
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());

--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/Settings.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/Settings.java
@@ -200,13 +200,13 @@ public class Settings {
         PreferenceManager.setDefaultValues(context, R.xml.preferences, true);
     }
 
-
-
     public void registerPreferenceChangeListener(SharedPreferences.OnSharedPreferenceChangeListener listener) {
         settings.registerOnSharedPreferenceChangeListener(listener);
     }
 
-
+    public void unregisterPreferenceChangeListener(SharedPreferences.OnSharedPreferenceChangeListener listener) {
+        settings.unregisterOnSharedPreferenceChangeListener(listener);
+    }
 
     public boolean getTapToReveal() {
         return getTapSingle() == Constants.TapMode.REVEAL || getTapDouble() == Constants.TapMode.REVEAL;


### PR DESCRIPTION
Began unregistering Shared Pref listeners on activities that have been destroyed. This ensures that we aren't getting callbacks to a destroyed activities, and also that we're not potentially modifying shared preferences multiple times (since a new listener would be registered on each activity creation).

Unrelated cleanup, set some fields in SettingsActivity to be private (since they weren't being used elsewhere).