### PR TITLE
fix: Correctly propagate backup failure status

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/BackupHelper.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/BackupHelper.java
@@ -120,12 +120,10 @@ public class BackupHelper {
             System.arraycopy(salt, 0, data, Constants.INT_LENGTH, Constants.ENCRYPTION_IV_LENGTH);
             System.arraycopy(encrypted, 0, data, Constants.INT_LENGTH + Constants.ENCRYPTION_IV_LENGTH, encrypted.length);
 
-            StorageAccessHelper.saveFile(context, uri, data);
+            return StorageAccessHelper.saveFile(context, uri, data);
         } catch (Exception e) {
             e.printStackTrace();
             return false;
         }
-
-        return true;
     }
 }


### PR DESCRIPTION
Fixes #671 
This change passes through the success/failure status of the file saving utility, to allow for displaying an error message in the UI.