### PR TITLE
Use an thumbnail if its name appears as a word in the TOTP issuer field

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Database/Entry.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Database/Entry.java
@@ -493,7 +493,11 @@ public class Entry {
         try {
             this.thumbnail = EntryThumbnail.EntryThumbnails.valueOfIgnoreCase(issuer);
         } catch(Exception e) {
-            this.thumbnail = EntryThumbnail.EntryThumbnails.Default;
+            try {
+                this.thumbnail = EntryThumbnail.EntryThumbnails.valueOfFuzzy(issuer);
+            } catch(Exception e2) {
+                this.thumbnail = EntryThumbnail.EntryThumbnails.Default;
+            }
         }
     }
 

--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EntryThumbnail.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EntryThumbnail.java
@@ -23,6 +23,8 @@
 
 package org.shadowice.flocke.andotp.Utilities;
 
+import java.util.regex.Pattern;
+
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -377,6 +379,15 @@ public class EntryThumbnail {
         public static EntryThumbnails valueOfIgnoreCase(String thumbnail) {
             for (EntryThumbnails entryThumbnails : values())
                 if (entryThumbnails.name().equalsIgnoreCase(thumbnail)) return entryThumbnails;
+            throw new IllegalArgumentException();
+        }
+
+        public static EntryThumbnails valueOfFuzzy(String thumbnail) {
+            for (EntryThumbnails entryThumbnails : values()) {
+                Pattern re = Pattern.compile("\\b" + Pattern.quote(entryThumbnails.name()) + "\\b", Pattern.CASE_INSENSITIVE);
+                if (re.matcher(thumbnail).find())
+	                return entryThumbnails;
+            }
             throw new IllegalArgumentException();
         }
 


### PR DESCRIPTION
This allows us to, e.g., use the GitLab icon when the issuer is `gitlab.com` but also when it is `gitlab.gnome.org`.

Fixes #685.