### PR TITLE
Add the feature to share the current OTP via an Intent

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/Constants.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/Constants.java
@@ -61,7 +61,7 @@ public class Constants {
     }
 
     public enum TapMode {
-        NOTHING, REVEAL, COPY, COPY_BACKGROUND
+        NOTHING, REVEAL, COPY, COPY_BACKGROUND, SEND_KEYSTROKES
     }
 
     public enum LabelDisplay {

--- a/app/src/main/java/org/shadowice/flocke/andotp/View/EntriesCardAdapter.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/View/EntriesCardAdapter.java
@@ -26,6 +26,7 @@ import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
@@ -319,6 +320,10 @@ public class EntriesCardAdapter extends RecyclerView.Adapter<EntryViewHolder>
                         establishPinIfNeeded(position);
                         copyHandler(position, text, true);
                         break;
+                    case SEND_KEYSTROKES:
+                        establishPinIfNeeded(position);
+                        sendKeystrokes(position);
+                        break;
                     default:
                         // If tap-to-reveal is disabled a single tab still needs to establish the PIN
                         if (!settings.getTapToReveal())
@@ -341,6 +346,10 @@ public class EntriesCardAdapter extends RecyclerView.Adapter<EntryViewHolder>
                     case COPY_BACKGROUND:
                         establishPinIfNeeded(position);
                         copyHandler(position, text, true);
+                        break;
+                    case SEND_KEYSTROKES:
+                        establishPinIfNeeded(position);
+                        sendKeystrokes(position);
                         break;
                     default:
                         break;
@@ -671,6 +680,19 @@ public class EntriesCardAdapter extends RecyclerView.Adapter<EntryViewHolder>
                 .show();
     }
 
+    // sends the current OTP code via a "Send Action" with the MIME type "text/x-keystrokes"
+    // other apps (eg. https://github.com/KDE/kdeconnect-android ) can listen for this and handle
+    // the current code on their own (eg. sending it to a connected device/browser/...)
+    private void sendKeystrokes(final int pos) {
+        String otp = displayedEntries.get(pos).getCurrentOTP();
+        Intent sendIntent = new Intent(Intent.ACTION_SEND);
+        sendIntent.setType("text/x-keystrokes");
+        sendIntent.putExtra(Intent.EXTRA_TEXT, otp);
+        if (sendIntent.resolveActivity(this.context.getPackageManager()) != null) {
+            this.context.startActivity(sendIntent);
+        }
+    }
+
     private void showQRCode(final int pos) {
         Uri uri = displayedEntries.get(pos).toUri();
         if (uri != null) {
@@ -728,6 +750,9 @@ public class EntriesCardAdapter extends RecyclerView.Adapter<EntryViewHolder>
                 return true;
             } else if (id == R.id.menu_popup_show_qr_code) {
                 showQRCode(pos);
+                return true;
+            } else if (id == R.id.menu_send_keystrokes) {
+                sendKeystrokes(pos);
                 return true;
             } else {
                 return false;

--- a/app/src/main/res/menu/menu_popup.xml
+++ b/app/src/main/res/menu/menu_popup.xml
@@ -22,4 +22,8 @@
         android:id="@+id/menu_popup_remove"
         android:title="@string/menu_popup_remove" />
 
+    <item
+        android:id="@+id/menu_send_keystrokes"
+        android:title="@string/menu_send_keystrokes" />
+
 </menu>

--- a/app/src/main/res/values-de/strings_main.xml
+++ b/app/src/main/res/values-de/strings_main.xml
@@ -45,6 +45,8 @@
     <string name="menu_popup_change_image">Bild ändern</string>
     <string name="menu_popup_remove">Entfernen</string>
     <string name="menu_popup_show_qr_code">Zeige QR-Code</string>
+    <string name="menu_send_keystrokes">Als Keystrokes teilen</string>
+
     <!-- Buttons -->
     <string name="button_card_options">Weitere Optionen</string>
     <string name="button_card_options_format">Weitere Optionen für %1$s</string>

--- a/app/src/main/res/values-de/strings_settings.xml
+++ b/app/src/main/res/values-de/strings_settings.xml
@@ -137,6 +137,7 @@
         <item>Anzeigen/Verstecken</item>
         <item>Kopieren</item>
         <item>Kopieren und in den Hintergrund wechseln</item>
+        <item>Als Keystrokes teilen</item>
     </string-array>
     <string-array name="settings_entries_search_includes">
         <item>Beschriftung</item>

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -133,6 +133,7 @@
         <item>reveal</item>
         <item>copy</item>
         <item>copy_background</item>
+        <item>send_keystrokes</item>
     </string-array>
 
     <string-array name="settings_values_search_includes" translatable="false">

--- a/app/src/main/res/values/strings_main.xml
+++ b/app/src/main/res/values/strings_main.xml
@@ -62,6 +62,7 @@
     <string name="menu_popup_remove">Remove</string>
     <string name="menu_popup_show_qr_code">Show QR Code</string>
     <string name="menu_popup_establish_pin">Enter pin</string>
+    <string name="menu_send_keystrokes">Share as Keystrokes</string>
 
     <!-- Buttons -->
     <string name="button_card_options">More options</string>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -205,6 +205,7 @@
         <item>Reveal/Hide</item>
         <item>Copy</item>
         <item>Copy and go to background</item>
+        <item>Share as Keystrokes</item>
     </string-array>
 
     <string-array name="settings_entries_search_includes">


### PR DESCRIPTION
Add the feature to share the current OTP via an Intent with the special mime-type "text/keystrokes"

Other apps could listen for this intents and pass the data to a connected desktop or other device where the 2FA code is needed.

I have also an open pull request on [KdeConnect](https://invent.kde.org/network/kdeconnect-android/-/merge_requests/220) which implements this functionality and it feels quite handy to pass the 2FA to the desktop. 

See here for a screen recording on how it works: https://imgur.com/a/uwjbESq / https://imgur.com/a/cBm5yOi

ToDo: maybe make it more visible or explain it somewhere in the app, so that users can find how to set this up (if no app is installed that explicitly filters for this mime type, the normal android chooser lets you share the text with any other app)
