### PR TITLE
Update tooling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ android:
     - platform-tools
     - tools
 
-    - build-tools-29.0.3
-    - android-29
+    - build-tools-30.0.3
+    - android-30
 
     - extra-google-m2repository
     - extra-android-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.3'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.3'
 
     defaultConfig {
         applicationId "org.shadowice.flocke.andotp"
         minSdkVersion 22
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 35
         versionName "0.8.0"
         vectorDrawables.useSupportLibrary = true
@@ -29,9 +29,9 @@ android {
         }
     }
     lintOptions {
-          abortOnError false
+        abortOnError false
     }
-    buildFeatures{
+    buildFeatures {
         dataBinding = true
     }
     flavorDimensions 'market'
@@ -55,7 +55,7 @@ android {
 }
 
 dependencies {
-    def lifecycle_version = "2.2.0"
+    def lifecycle_version = "2.3.0"
 
     implementation 'androidx.media:media:1.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
@@ -65,14 +65,19 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation "androidx.lifecycle:lifecycle-process:${lifecycle_version}"
     implementation "androidx.lifecycle:lifecycle-common-java8:${lifecycle_version}"
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'com.google.android.material:material:1.3.0'
 
     //noinspection GradleDependency - because they messed up their version numbering
     implementation "commons-codec:commons-codec:1.15"
     implementation "com.github.aakira:expandable-layout:1.6.0"
     implementation "com.heinrichreimersoftware:material-intro:2.0.0"
-    implementation("com.journeyapps:zxing-android-embedded:4.1.0"){ transitive = false }
-    implementation "com.google.zxing:core:3.3.0" // Keep pinned to 3.3.0 to support SDK versions below 24
+    implementation("com.journeyapps:zxing-android-embedded:4.1.0") { transitive = false }
+    implementation('com.google.zxing:core') {
+        version {
+            strictly '[3.3, 3.4[' // Keep pinned below 3.4 to support SDK versions below 24
+            prefer '3.3.0'
+        }
+    }
     implementation "com.vanniktech:vntnumberpickerpreference:1.0.0"
     implementation "me.zhanghai.android.materialprogressbar:library:1.6.1"
     implementation "org.sufficientlysecure:openpgp-api:12.0"
@@ -80,5 +85,5 @@ dependencies {
     implementation "com.mikepenz:aboutlibraries:6.2.3" // Supporting a newer version will need some work
 
     androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.1'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Oct 18 10:46:52 CEST 2020
+#Sat Dec 12 17:01:19 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
 Updating build environment, tools, dependencies and travis build

 - update compileSdkVersion to 30
 - update buildToolsVersion to 30.0.3
 - update targetSdkVersion to 30
 - update androidx.media:media to 1.2.1
 - update androidx.constraintlayout:constraintlayout to 2.0.4
 - update androidx.lifecycle to 2.3.0
 - update com.android.tools:desugar_jdk_libs to 1.1.5
 - update com.google.android.material:material to 1.3.0
 - pin com.google.zxing:core version below 3.4