### PR TITLE
#635 move authentication to a background thread

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
@@ -63,6 +63,7 @@ public class AuthenticateActivity extends ThemedActivity
     private String existingAuthCredentials;
     private boolean isAuthUpgrade = false;
 
+    private TextInputLayout passwordLayout;
     private TextInputEditText passwordInput;
     private Button unlockButton;
     private ProgressBar unlockProgress;
@@ -127,16 +128,15 @@ public class AuthenticateActivity extends ThemedActivity
     }
 
     private void initPasswordLayoutView(View v) {
-        TextInputLayout passwordLayout = v.findViewById(R.id.passwordLayout);
-
+        passwordLayout = v.findViewById(R.id.passwordLayout);
         int hintResId = (authMethod == AuthMethod.PASSWORD) ? R.string.auth_hint_password : R.string.auth_hint_pin;
         passwordLayout.setHint(getString(hintResId));
-
-        if (settings.getBlockAccessibility())
+        if (settings.getBlockAccessibility()) {
             passwordLayout.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && settings.getBlockAutofill())
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && settings.getBlockAutofill()) {
             passwordLayout.setImportantForAutofill(View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS);
+        }
     }
 
     private void initPasswordInputView(View v) {
@@ -152,9 +152,7 @@ public class AuthenticateActivity extends ThemedActivity
     private void initUnlockViews(View v) {
         unlockButton = v.findViewById(R.id.buttonUnlock);
         unlockButton.setOnClickListener(this);
-        unlockButton.setVisibility(View.VISIBLE);
         unlockProgress = v.findViewById(R.id.unlockProgress);
-        unlockProgress.setVisibility(View.GONE);
     }
 
     @Override
@@ -182,6 +180,7 @@ public class AuthenticateActivity extends ThemedActivity
     }
 
     private void displayUnlockProgress() {
+        passwordLayout.setEnabled(false);
         passwordInput.setEnabled(false);
         unlockButton.setEnabled(false);
         unlockButton.setVisibility(View.INVISIBLE);

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
@@ -62,8 +62,6 @@ public class AuthenticateActivity extends ThemedActivity
     private String existingAuthCredentials;
     private boolean isAuthUpgrade = false;
 
-    private boolean isTaskRunning = false;
-
     private TextInputLayout passwordLayout;
     private TextInputEditText passwordInput;
     private Button unlockButton;
@@ -72,8 +70,6 @@ public class AuthenticateActivity extends ThemedActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        checkBackgroundTask();
-
         if (! settings.getScreenshotsEnabled())
             getWindow().setFlags(LayoutParams.FLAG_SECURE, LayoutParams.FLAG_SECURE);
 
@@ -101,21 +97,8 @@ public class AuthenticateActivity extends ThemedActivity
         setContentView(R.layout.activity_container);
         initToolbar();
         initPasswordViews();
-        if (isTaskRunning) {
-            setupUiForRunningTask();
-        }
 
         getWindow().setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
-    }
-
-    private void checkBackgroundTask() {
-        TaskFragment taskFragment = findTaskFragment();
-        if (taskFragment != null) {
-            // If we have the task fragment in our fragment manager, we know that we started the
-            // task before a configuration change and need to set a new callback.
-            isTaskRunning = true;
-            taskFragment.task.setCallback(this::handleResult);
-        }
     }
 
     @Nullable
@@ -174,8 +157,23 @@ public class AuthenticateActivity extends ThemedActivity
         unlockProgress = v.findViewById(R.id.unlockProgress);
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        checkBackgroundTask();
+    }
+
+    private void checkBackgroundTask() {
+        TaskFragment taskFragment = findTaskFragment();
+        if (taskFragment != null) {
+            // If we have the task fragment in our fragment manager, we know that we started the
+            // task before a configuration change and need to set a new callback.
+            taskFragment.task.setCallback(this::handleResult);
+            setupUiForRunningTask();
+        }
+    }
+
     private void setupUiForRunningTask() {
-        isTaskRunning = true;
         passwordLayout.setEnabled(false);
         passwordInput.setEnabled(false);
         unlockButton.setEnabled(false);

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
@@ -23,6 +23,7 @@
 package org.shadowice.flocke.andotp.Activities;
 
 import android.app.Fragment;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
@@ -44,6 +45,7 @@ import android.view.View;
 import android.view.ViewStub;
 import android.view.WindowManager.LayoutParams;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ProgressBar;
@@ -193,10 +195,21 @@ public class AuthenticateActivity extends BaseActivity
 
     private void checkBackgroundTask() {
         TaskFragment taskFragment = findTaskFragment();
-        if (taskFragment != null && !taskFragment.task.isCanceled()) {
-            taskFragment.task.setCallback(this::handleResult);
-            setupUiForTaskState(true);
+        if (taskFragment != null) {
+            if (taskFragment.task.isCanceled()) {
+                resetPasswordInput();
+            } else {
+                taskFragment.task.setCallback(this::handleResult);
+                setupUiForTaskState(true);
+            }
         }
+    }
+
+    private void resetPasswordInput() {
+        passwordInput.setText("");
+        passwordInput.requestFocus();
+        InputMethodManager keyboard = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+        keyboard.showSoftInput(passwordInput, 0);
     }
 
     @Nullable

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
@@ -197,6 +197,10 @@ public class AuthenticateActivity extends BaseActivity
         TaskFragment taskFragment = findTaskFragment();
         if (taskFragment != null) {
             if (taskFragment.task.isCanceled()) {
+                // The task was canceled, so remove the task fragment and reset password input.
+                getFragmentManager().beginTransaction()
+                        .remove(taskFragment)
+                        .commit();
                 resetPasswordInput();
             } else {
                 taskFragment.task.setCallback(this::handleResult);

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
@@ -32,6 +32,9 @@ import com.google.android.material.textfield.TextInputLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.ProcessLifecycleOwner;
 
 import android.text.Editable;
 import android.text.InputType;
@@ -105,6 +108,9 @@ public class AuthenticateActivity extends BaseActivity
                     cancelBackgroundTask();
                 }
             });
+
+        ProcessLifecycleOwner.get().getLifecycle()
+                .addObserver(new ProcessLifecycleObserver());
 
         getWindow().setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
     }
@@ -193,6 +199,15 @@ public class AuthenticateActivity extends BaseActivity
         unlockButton.setEnabled(!isTaskRunning);
         unlockButton.setVisibility(isTaskRunning? View.INVISIBLE : View.VISIBLE);
         unlockProgress.setVisibility(isTaskRunning ? View.VISIBLE : View.GONE);
+    }
+
+    private class ProcessLifecycleObserver implements DefaultLifecycleObserver {
+        @Override
+        public void onStop(LifecycleOwner owner) {
+            if (settings.getRelockOnBackground()) {
+                cancelBackgroundTask();
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
@@ -213,13 +213,6 @@ public class AuthenticateActivity extends BaseActivity
     }
 
     @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        ProcessLifecycleOwner.get().getLifecycle()
-                .removeObserver(observer);
-    }
-
-    @Override
     public void onClick(View view) {
         Editable text = passwordInput.getText();
         startAuthTask(text != null ? text.toString() : "");
@@ -272,6 +265,12 @@ public class AuthenticateActivity extends BaseActivity
     }
 
     @Override
+    public void onBackPressed() {
+        finishWithResult(false, null);
+        super.onBackPressed();
+    }
+
+    @Override
     protected void onPause() {
         super.onPause();
         // We don't want the task to callback to a dead activity and cause a memory leak, so null it here.
@@ -282,9 +281,15 @@ public class AuthenticateActivity extends BaseActivity
     }
 
     @Override
-    public void onBackPressed() {
-        finishWithResult(false, null);
-        super.onBackPressed();
+    protected void onDestroy() {
+        ProcessLifecycleOwner.get().getLifecycle()
+                .removeObserver(observer);
+        super.onDestroy();
+    }
+
+    @Override
+    protected boolean shouldDestroyOnScreenOff() {
+        return false;
     }
 
     /** Retained instance fragment to hold a running {@link AuthenticationTask} between configuration changes.*/

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
@@ -45,7 +45,6 @@ import android.widget.Toast;
 
 import org.shadowice.flocke.andotp.R;
 import org.shadowice.flocke.andotp.Tasks.AuthenticationTask;
-import org.shadowice.flocke.andotp.Tasks.AuthenticationTask.Callback;
 import org.shadowice.flocke.andotp.Tasks.AuthenticationTask.Result;
 import org.shadowice.flocke.andotp.Utilities.Constants;
 
@@ -55,8 +54,6 @@ import static org.shadowice.flocke.andotp.Utilities.Constants.AuthMethod;
 
 public class AuthenticateActivity extends ThemedActivity
         implements EditText.OnEditorActionListener, View.OnClickListener {
-
-    private static final String KEY_WAS_TASK_ACTIVE = "AuthenticateActivity.WasTaskActive";
 
     private AuthMethod authMethod;
     private String newEncryption = "";

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
@@ -66,6 +66,7 @@ public class AuthenticateActivity extends BaseActivity
     private String newEncryption = "";
     private String existingAuthCredentials;
     private boolean isAuthUpgrade = false;
+    private ProcessLifecycleObserver observer;
 
     private TextInputLayout passwordLayout;
     private TextInputEditText passwordInput;
@@ -109,8 +110,9 @@ public class AuthenticateActivity extends BaseActivity
                 }
             });
 
+        observer = new ProcessLifecycleObserver();
         ProcessLifecycleOwner.get().getLifecycle()
-                .addObserver(new ProcessLifecycleObserver());
+                .addObserver(observer);
 
         getWindow().setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
     }
@@ -174,6 +176,15 @@ public class AuthenticateActivity extends BaseActivity
         setupUiForTaskState(false);
     }
 
+    private class ProcessLifecycleObserver implements DefaultLifecycleObserver {
+        @Override
+        public void onStop(LifecycleOwner owner) {
+            if (settings.getRelockOnBackground()) {
+                cancelBackgroundTask();
+            }
+        }
+    }
+
     @Override
     public void onResume() {
         super.onResume();
@@ -201,13 +212,11 @@ public class AuthenticateActivity extends BaseActivity
         unlockProgress.setVisibility(isTaskRunning ? View.VISIBLE : View.GONE);
     }
 
-    private class ProcessLifecycleObserver implements DefaultLifecycleObserver {
-        @Override
-        public void onStop(LifecycleOwner owner) {
-            if (settings.getRelockOnBackground()) {
-                cancelBackgroundTask();
-            }
-        }
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        ProcessLifecycleOwner.get().getLifecycle()
+                .removeObserver(observer);
     }
 
     @Override

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
@@ -246,7 +246,7 @@ public class AuthenticateActivity extends ThemedActivity
         super.onBackPressed();
     }
 
-    /** Retained instance fragment to hold a running @link{{@link AuthenticationTask}} between configuration changes.*/
+    /** Retained instance fragment to hold a running {@link AuthenticationTask} between configuration changes.*/
     public static class TaskFragment extends Fragment {
 
         AuthenticationTask task;

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/BaseActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/BaseActivity.java
@@ -43,13 +43,7 @@ public abstract class BaseActivity extends ThemedActivity {
     @Override
     protected void onDestroy() {
         unregisterReceiver(screenOffReceiver);
-
         super.onDestroy();
-    }
-
-    private void destroyIfNotMain() {
-        if (getClass() != MainActivity.class)
-            finish();
     }
 
     public void setBroadcastCallback(BroadcastReceivedCallback cb) {
@@ -62,12 +56,18 @@ public abstract class BaseActivity extends ThemedActivity {
         @Override
         public void onReceive(Context context, Intent intent) {
             if (intent.getAction().equals(Intent.ACTION_SCREEN_OFF)) {
-                if (broadcastReceivedCallback != null)
+                if (broadcastReceivedCallback != null) {
                     broadcastReceivedCallback.onReceivedScreenOff();
-
-                destroyIfNotMain();
+                }
+                if (shouldDestroyOnScreenOff()) {
+                    finish();
+                }
             }
         }
+    }
+
+    protected boolean shouldDestroyOnScreenOff() {
+        return getClass() != MainActivity.class;
     }
 
     interface BroadcastReceivedCallback {

--- a/app/src/main/java/org/shadowice/flocke/andotp/Tasks/AuthenticationTask.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Tasks/AuthenticationTask.java
@@ -1,0 +1,120 @@
+package org.shadowice.flocke.andotp.Tasks;
+
+import android.content.Context;
+import android.os.AsyncTask;
+import android.util.Base64;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.shadowice.flocke.andotp.Tasks.AuthenticationTask.Result;
+import org.shadowice.flocke.andotp.Utilities.Constants.AuthMethod;
+import org.shadowice.flocke.andotp.Utilities.EncryptionHelper;
+import org.shadowice.flocke.andotp.Utilities.EncryptionHelper.PBKDF2Credentials;
+import org.shadowice.flocke.andotp.Utilities.Settings;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+
+public class AuthenticationTask extends AsyncTask<Void, Void, Result> {
+
+    private final Settings settings;
+    private final Callback callback;
+
+    private final boolean isAuthUpgrade;
+    private final String existingAuthCredentials;
+    private final String plainPassword;
+
+    public AuthenticationTask(Context context, Callback callback, boolean isAuthUpgrade, String existingAuthCredentials, String plainPassword) {
+        Context applicationContext = context.getApplicationContext();
+        this.settings = new Settings(applicationContext);
+        this.callback = callback;
+
+        this.isAuthUpgrade = isAuthUpgrade;
+        this.existingAuthCredentials = existingAuthCredentials;
+        this.plainPassword = plainPassword;
+    }
+
+    @Override
+    @NonNull
+    protected Result doInBackground(Void... ignore) {
+        if (isAuthUpgrade) {
+            return upgradeAuthentication();
+        } else {
+            return confirmAuthentication();
+        }
+    }
+
+    @NonNull
+    private Result confirmAuthentication() {
+        try {
+            PBKDF2Credentials credentials = EncryptionHelper.generatePBKDF2Credentials(plainPassword, settings.getSalt(), settings.getIterations());
+            byte[] passwordArray = Base64.decode(existingAuthCredentials, Base64.URL_SAFE);
+
+            if (Arrays.equals(passwordArray, credentials.password)) {
+                return Result.success(credentials.key);
+            }
+            return Result.failure();
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException | IllegalArgumentException e) {
+            Log.e("DecodePasswordTask", "Problem decoding password", e);
+            return Result.failure();
+        }
+    }
+
+    @NonNull
+    private Result upgradeAuthentication() {
+        String hashedPassword = new String(Hex.encodeHex(DigestUtils.sha256(plainPassword)));
+        if (!hashedPassword.equals(existingAuthCredentials))
+            return Result.failure();
+
+        byte[] key = settings.setAuthCredentials(plainPassword);
+
+        AuthMethod authMethod = settings.getAuthMethod();
+        if (authMethod == AuthMethod.PASSWORD)
+            settings.removeAuthPasswordHash();
+        else if (authMethod == AuthMethod.PIN)
+            settings.removeAuthPINHash();
+
+        if (key == null)
+            return Result.upgradeFailure();
+        else
+            return Result.success(key);
+    }
+
+    @Override
+    protected void onPostExecute(Result result) {
+        callback.onComplete(result);
+    }
+
+    @FunctionalInterface
+    public interface Callback {
+        void onComplete(Result result);
+    }
+
+    public static class Result {
+        @Nullable
+        public final byte[] encryptionKey;
+        public final boolean authUpgradeFailed;
+
+        public Result(@Nullable byte[] encryptionKey, boolean authUpgradeFailed) {
+            this.encryptionKey = encryptionKey;
+            this.authUpgradeFailed = authUpgradeFailed;
+        }
+
+        public static Result success(byte[] encryptionKey) {
+            return new Result(encryptionKey, false);
+        }
+
+        public static Result upgradeFailure() {
+            return new Result(null, true);
+        }
+
+        public static Result failure() {
+            return new Result(null, false);
+        }
+    }
+}

--- a/app/src/main/java/org/shadowice/flocke/andotp/Tasks/AuthenticationTask.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Tasks/AuthenticationTask.java
@@ -50,22 +50,6 @@ public class AuthenticationTask extends AsyncTask<Void, Void, Result> {
     }
 
     @NonNull
-    private Result confirmAuthentication() {
-        try {
-            PBKDF2Credentials credentials = EncryptionHelper.generatePBKDF2Credentials(plainPassword, settings.getSalt(), settings.getIterations());
-            byte[] passwordArray = Base64.decode(existingAuthCredentials, Base64.URL_SAFE);
-
-            if (Arrays.equals(passwordArray, credentials.password)) {
-                return Result.success(credentials.key);
-            }
-            return Result.failure();
-        } catch (NoSuchAlgorithmException | InvalidKeySpecException | IllegalArgumentException e) {
-            Log.e("DecodePasswordTask", "Problem decoding password", e);
-            return Result.failure();
-        }
-    }
-
-    @NonNull
     private Result upgradeAuthentication() {
         String hashedPassword = new String(Hex.encodeHex(DigestUtils.sha256(plainPassword)));
         if (!hashedPassword.equals(existingAuthCredentials))
@@ -83,6 +67,22 @@ public class AuthenticationTask extends AsyncTask<Void, Void, Result> {
             return Result.upgradeFailure();
         else
             return Result.success(key);
+    }
+
+    @NonNull
+    private Result confirmAuthentication() {
+        try {
+            PBKDF2Credentials credentials = EncryptionHelper.generatePBKDF2Credentials(plainPassword, settings.getSalt(), settings.getIterations());
+            byte[] passwordArray = Base64.decode(existingAuthCredentials, Base64.URL_SAFE);
+
+            if (Arrays.equals(passwordArray, credentials.password)) {
+                return Result.success(credentials.key);
+            }
+            return Result.failure();
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException | IllegalArgumentException e) {
+            Log.e("DecodePasswordTask", "Problem decoding password", e);
+            return Result.failure();
+        }
     }
 
     @Override

--- a/app/src/main/java/org/shadowice/flocke/andotp/Tasks/AuthenticationTask.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Tasks/AuthenticationTask.java
@@ -80,7 +80,7 @@ public class AuthenticationTask extends AsyncTask<Void, Void, Result> {
             }
             return Result.failure();
         } catch (NoSuchAlgorithmException | InvalidKeySpecException | IllegalArgumentException e) {
-            Log.e("DecodePasswordTask", "Problem decoding password", e);
+            Log.e("AuthenticationTask", "Problem decoding password", e);
             return Result.failure();
         }
     }

--- a/app/src/main/java/org/shadowice/flocke/andotp/Tasks/AuthenticationTask.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Tasks/AuthenticationTask.java
@@ -28,6 +28,11 @@ public class AuthenticationTask extends UiBasedBackgroundTask<Result> {
     private final String existingAuthCredentials;
     private final String plainPassword;
 
+    /**
+     * @param context Context to be used to query settings (the application Context will be used to avoid memory leaks).
+     * @param isAuthUpgrade true if this is an authentication upgrade and new credentials should be saved, false if this is just confirmation.
+     * @param existingAuthCredentials The existing hashed authentication credentials that we have stored.
+     * @param plainPassword The plaintext user-entered password to check authentication with. */
     public AuthenticationTask(Context context, boolean isAuthUpgrade, String existingAuthCredentials, String plainPassword) {
         super(Result.failure());
         Context applicationContext = context.getApplicationContext();

--- a/app/src/main/java/org/shadowice/flocke/andotp/Tasks/AuthenticationTask.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Tasks/AuthenticationTask.java
@@ -20,19 +20,18 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
 
-public class AuthenticationTask extends AsyncTask<Void, Void, Result> {
+public class AuthenticationTask extends UiBasedBackgroundTask<Result> {
 
     private final Settings settings;
-    private final Callback callback;
 
     private final boolean isAuthUpgrade;
     private final String existingAuthCredentials;
     private final String plainPassword;
 
-    public AuthenticationTask(Context context, Callback callback, boolean isAuthUpgrade, String existingAuthCredentials, String plainPassword) {
+    public AuthenticationTask(Context context, boolean isAuthUpgrade, String existingAuthCredentials, String plainPassword) {
+        super(Result.failure());
         Context applicationContext = context.getApplicationContext();
         this.settings = new Settings(applicationContext);
-        this.callback = callback;
 
         this.isAuthUpgrade = isAuthUpgrade;
         this.existingAuthCredentials = existingAuthCredentials;
@@ -41,7 +40,7 @@ public class AuthenticationTask extends AsyncTask<Void, Void, Result> {
 
     @Override
     @NonNull
-    protected Result doInBackground(Void... ignore) {
+    protected Result doInBackground() {
         if (isAuthUpgrade) {
             return upgradeAuthentication();
         } else {
@@ -83,16 +82,6 @@ public class AuthenticationTask extends AsyncTask<Void, Void, Result> {
             Log.e("AuthenticationTask", "Problem decoding password", e);
             return Result.failure();
         }
-    }
-
-    @Override
-    protected void onPostExecute(Result result) {
-        callback.onComplete(result);
-    }
-
-    @FunctionalInterface
-    public interface Callback {
-        void onComplete(Result result);
     }
 
     public static class Result {

--- a/app/src/main/java/org/shadowice/flocke/andotp/Tasks/UiBasedBackgroundTask.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Tasks/UiBasedBackgroundTask.java
@@ -1,0 +1,89 @@
+package org.shadowice.flocke.andotp.Tasks;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import androidx.annotation.AnyThread;
+import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/** Encapsulates a background task that needs to communicate back to the UI (on the main thread) to
+ * provide a result. */
+public abstract class UiBasedBackgroundTask<Result> {
+
+    private final Result failedResult;
+    private final ExecutorService executor;
+    private final Handler mainThreadHandler;
+
+    private final Object callbackLock = new Object();
+    @Nullable
+    private UiCallback<Result> callback;
+    @Nullable
+    private Result awaitedResult;
+
+    /** @param failedResult The result to return if the task fails (throws an exception or returns null). */
+    public UiBasedBackgroundTask(@NonNull Result failedResult) {
+        this.failedResult = failedResult;
+        this.executor = Executors.newSingleThreadExecutor();
+        this.mainThreadHandler = new Handler(Looper.getMainLooper());
+    }
+
+    /** @param callback If null, any results which may arrive from a currently executing task will
+     *                   be stored until a new callback is set. */
+    public void setCallback(@Nullable UiCallback<Result> callback) {
+        synchronized (callbackLock) {
+            this.callback = callback;
+            // If we have an awaited result and are setting a new callback, publish the result immediately.
+            if (awaitedResult != null && callback != null) {
+                emitResultOnMainThread(callback, awaitedResult);
+            }
+        }
+    }
+
+    private void emitResultOnMainThread(@NonNull UiCallback<Result> callback, @NonNull Result result) {
+        mainThreadHandler.post(() -> callback.onResult(result));
+        this.callback = null;
+        this.awaitedResult = null;
+    }
+
+    /** Executed the task on a background thread. Safe to call from the main thread. */
+    @AnyThread
+    public void execute() {
+        executor.execute(this::runTask);
+    }
+
+    private void runTask() {
+        Result result = failedResult;
+        try {
+            result = doInBackground();
+        } catch (Exception e) {
+            Log.e("UiBasedBackgroundTask", "Problem running background task", e);
+        }
+
+        synchronized (callbackLock) {
+            if (callback != null) {
+                emitResultOnMainThread(callback, result);
+            } else {
+                awaitedResult = result;
+            }
+        }
+    }
+
+    /** Work to be done in a background thread.
+     * @return Return the result from this task's execution.
+     * @throws Exception If an Exception is thrown from this task's execution, it will be logged
+     *         and the provided default Result will be returned. */
+    @NonNull
+    protected abstract Result doInBackground() throws Exception;
+
+    @FunctionalInterface
+    public interface UiCallback<Result> {
+        @MainThread
+        void onResult(@NonNull Result result);
+    }
+}

--- a/app/src/main/res/layout/content_authenticate.xml
+++ b/app/src/main/res/layout/content_authenticate.xml
@@ -52,7 +52,8 @@
             android:layout_height="wrap_content"
             style="?android:attr/progressBarStyle"
             android:layout_centerVertical="true"
-            android:layout_alignEnd="@id/buttonUnlock"/>
+            android:layout_alignEnd="@id/buttonUnlock"
+            android:visibility="gone"/>
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/content_authenticate.xml
+++ b/app/src/main/res/layout/content_authenticate.xml
@@ -34,12 +34,26 @@
     <requestFocus/>
     </com.google.android.material.textfield.TextInputLayout>
 
-    <Button
-        android:id="@+id/buttonUnlock"
+    <RelativeLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="end"
-        style="?android:attr/buttonBarButtonStyle"
-        android:text="@string/auth_button_unlock" />
+        android:layout_gravity="end">
+
+        <Button
+            android:id="@+id/buttonUnlock"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="?android:attr/buttonBarButtonStyle"
+            android:text="@string/auth_button_unlock" />
+
+        <ProgressBar
+            android:id="@+id/unlockProgress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="?android:attr/progressBarStyle"
+            android:layout_centerVertical="true"
+            android:layout_alignEnd="@id/buttonUnlock"/>
+
+    </RelativeLayout>
 
 </LinearLayout>


### PR DESCRIPTION
Ok, so I added an ASyncTask to run the authentication code, with a callback to the Activity when it completes (still finishing the Activity on the main thread). While the task is running, I added an indeterminate progress bar that replaces the "unlock" button to provide some feedback to the user: 

https://user-images.githubusercontent.com/1057406/106338658-56f2c580-6262-11eb-8816-9c88006b6d2f.mp4

One small caveat here is that I call `.get()` on the task if the Activity is being paused. I did this to prevent the task from calling back to a dead activity for the case where the user initiates the unlock process and rotates their phone (or some other config change). 

If this situation happens, the task will complete and the Activity will finish as expected, however the main thread will be locked while `.get()` is called (as it was before). Locking the main thread here isn't ideal, but seeing as this is a short-lived (1-2 second) task and the situation is unlikely to happen it's probably not a big issue. 

To get around this we'd probably have to start using a retained fragment within the Activity (to store the task), and then in `onCreate` check for that retained fragment and tie the newly created Activity into it for a callback. This is definitely doable, however it'd probably make more sense to wait and see if we implement a general background execution scheme for the app before doing that work.
    
Let me know if you see any issues and I'll make necessary changes. I tested this on a Samsung device and on an emulator for both the cases of regular login and changing/upgrading authentication, with configuration changes in between and didn't run into any issues with the changes.