### PR TITLE
#740 authentication dialog keyboard switch

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Preferences/CredentialsPreference.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Preferences/CredentialsPreference.java
@@ -244,57 +244,43 @@ public class CredentialsPreference extends DialogPreference
     }
 
     private void updateLayout() {
-        if (value == AuthMethod.NONE) {
+        if (value == AuthMethod.NONE || value == AuthMethod.DEVICE) {
             credentialsLayout.setVisibility(View.GONE);
-
-            if (getDialog() != null)
-                UIHelper.hideKeyboard(getContext(), getDialog().getCurrentFocus());
-
+            if (getDialog() != null) {
+                UIHelper.hideKeyboard(getContext(), passwordInput);
+            }
             btnSave.setEnabled(true);
-        } else if (value == AuthMethod.PASSWORD) {
-            credentialsLayout.setVisibility(View.VISIBLE);
-
-            passwordLayout.setHint(getContext().getString(R.string.settings_hint_password));
-            passwordConfirm.setHint(R.string.settings_hint_password_confirm);
-
-            passwordInput.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-            passwordConfirm.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-
-            ConfirmedPasswordTransformationHelper.setup(passwordLayout, passwordInput, passwordConfirm);
-
-            minLength = Constants.AUTH_MIN_PASSWORD_LENGTH;
-            toShortWarning.setText(getContext().getString(R.string.settings_label_short_password, minLength));
-
-            passwordInput.requestFocus();
-            UIHelper.showKeyboard(getContext(), passwordInput);
-
-            btnSave.setEnabled(false);
-        } else if (value == AuthMethod.PIN) {
-            credentialsLayout.setVisibility(View.VISIBLE);
-
-            passwordLayout.setHint(getContext().getString(R.string.settings_hint_pin));
-            passwordConfirm.setHint(R.string.settings_hint_pin_confirm);
-
-            passwordInput.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_PASSWORD);
-            passwordConfirm.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_PASSWORD);
-
-            ConfirmedPasswordTransformationHelper.setup(passwordLayout, passwordInput, passwordConfirm);
-
-            minLength = Constants.AUTH_MIN_PIN_LENGTH;
-            toShortWarning.setText(getContext().getString(R.string.settings_label_short_pin, minLength));
-
-            passwordInput.requestFocus();
-            UIHelper.showKeyboard(getContext(), passwordInput);
-
-            btnSave.setEnabled(false);
-        } else if (value == AuthMethod.DEVICE) {
-            credentialsLayout.setVisibility(View.GONE);
-
-            if (getDialog() != null)
-                UIHelper.hideKeyboard(getContext(), getDialog().getCurrentFocus());
-
-            btnSave.setEnabled(true);
+        } else if (value == AuthMethod.PASSWORD || value == AuthMethod.PIN) {
+            prepareAuthMethodInputFields();
         }
+    }
+
+    private void prepareAuthMethodInputFields() {
+        if (value != AuthMethod.PIN && value != AuthMethod.PASSWORD) {
+            return;
+        }
+        boolean isPassword = value == AuthMethod.PASSWORD;
+
+        credentialsLayout.setVisibility(View.VISIBLE);
+        int layoutHintRes = isPassword ? R.string.settings_hint_password : R.string.settings_hint_pin;
+        passwordLayout.setHint(getContext().getString(layoutHintRes));
+        int confirmHintRes = isPassword ? R.string.settings_hint_password_confirm : R.string.settings_hint_pin_confirm;
+        passwordConfirm.setHint(confirmHintRes);
+
+        int inputType = isPassword ?
+                (InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD) :
+                (InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_PASSWORD);
+        passwordInput.setInputType(inputType);
+        passwordConfirm.setInputType(inputType);
+        ConfirmedPasswordTransformationHelper.setup(passwordLayout, passwordInput, passwordConfirm);
+
+        minLength = isPassword ? Constants.AUTH_MIN_PASSWORD_LENGTH : Constants.AUTH_MIN_PIN_LENGTH;
+        int shortWarningRes = isPassword ? R.string.settings_label_short_password : R.string.settings_label_short_pin;
+        toShortWarning.setText(getContext().getString(shortWarningRes, minLength));
+
+        passwordInput.requestFocus();
+        UIHelper.showKeyboard(getContext(), passwordInput);
+        btnSave.setEnabled(false);
     }
 
     @Override

--- a/app/src/main/java/org/shadowice/flocke/andotp/Preferences/CredentialsPreference.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Preferences/CredentialsPreference.java
@@ -30,7 +30,6 @@ import android.preference.DialogPreference;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
-import android.text.method.PasswordTransformationMethod;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.AdapterView;
@@ -67,7 +66,7 @@ public class CredentialsPreference extends DialogPreference
         boolean testEncryptionChange(byte[] newKey);
     }
 
-    private List<String> entries;
+    private final List<String> entries;
     private static final List<AuthMethod> entryValues = Arrays.asList(
             AuthMethod.NONE,
             AuthMethod.PASSWORD,
@@ -77,7 +76,7 @@ public class CredentialsPreference extends DialogPreference
 
     private int minLength = 0;
 
-    private Settings settings;
+    private final Settings settings;
     private AuthMethod value = AuthMethod.NONE;
     private EncryptionChangeCallback encryptionChangeCallback = null;
 
@@ -230,14 +229,10 @@ public class CredentialsPreference extends DialogPreference
 
         if (password.length() >= minLength) {
             toShortWarning.setVisibility(View.GONE);
-
             String confirm = passwordConfirm.getEditableText().toString();
 
-            if (!password.isEmpty() && !confirm.isEmpty() && password.equals(confirm)) {
-                btnSave.setEnabled(true);
-            } else {
-                btnSave.setEnabled(false);
-            }
+            boolean canSave = !password.isEmpty() && !confirm.isEmpty() && password.equals(confirm);
+            btnSave.setEnabled(canSave);
         } else {
             toShortWarning.setVisibility(View.VISIBLE);
         }

--- a/app/src/main/java/org/shadowice/flocke/andotp/Preferences/CredentialsPreference.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Preferences/CredentialsPreference.java
@@ -287,6 +287,12 @@ public class CredentialsPreference extends DialogPreference
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         value = entryValues.get(position);
         updateLayout();
+        clearInputFields();
+    }
+
+    private void clearInputFields() {
+        passwordInput.setText(null);
+        passwordConfirm.setText(null);
     }
 
     // Needed stub functions

--- a/app/src/main/java/org/shadowice/flocke/andotp/Preferences/CredentialsPreference.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Preferences/CredentialsPreference.java
@@ -257,6 +257,9 @@ public class CredentialsPreference extends DialogPreference
             passwordLayout.setHint(getContext().getString(R.string.settings_hint_password));
             passwordConfirm.setHint(R.string.settings_hint_password_confirm);
 
+            passwordInput.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+            passwordConfirm.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+
             ConfirmedPasswordTransformationHelper.setup(passwordLayout, passwordInput, passwordConfirm);
 
             passwordInput.setTransformationMethod(new PasswordTransformationMethod());

--- a/app/src/main/java/org/shadowice/flocke/andotp/Preferences/CredentialsPreference.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Preferences/CredentialsPreference.java
@@ -262,9 +262,6 @@ public class CredentialsPreference extends DialogPreference
 
             ConfirmedPasswordTransformationHelper.setup(passwordLayout, passwordInput, passwordConfirm);
 
-            passwordInput.setTransformationMethod(new PasswordTransformationMethod());
-            passwordConfirm.setTransformationMethod(new PasswordTransformationMethod());
-
             minLength = Constants.AUTH_MIN_PASSWORD_LENGTH;
             toShortWarning.setText(getContext().getString(R.string.settings_label_short_password, minLength));
 


### PR DESCRIPTION
Sorry, it looks like I actually added this initial bug in commit b0c56b3 (I wasn't setting the input type when switching to password). I changed that, and fixed a few other small bugs that I found while looking at it:

- Began clearing the input fields when switching auth methods. We weren't doing this before, and you could technically therefore switch from password (entering alpha chars) and back to PIN and save it as long as they matched up. This is an unlikely case that the user would have to actively try to mess up, but it would mean you wouldn't be able to login (since the user would only be presented with a number keyboard when logging in later on).
- Began hiding the keyboard on proper input when switching auth methods. Before the keyboard wasn't being hidden when choosing none/device.

Also did some simple code cleanup (condensed some methods).