### PR TITLE
Comment thumbnail request instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/thumbnail-request.md
+++ b/.github/ISSUE_TEMPLATE/thumbnail-request.md
@@ -7,7 +7,7 @@ assignees: flocke, RichyHBM, ziegenberg
 
 ---
 
-Please fill in **all the information below** to help speed up the process!
+<!-- Please fill in **all the information below** to help speed up the process! -->
 
 **Name**:
 **Website**:


### PR DESCRIPTION
Comment thumbnail request instructions.

This way the user still sees the instructions when editing their request, but afterwards they aren't shown in the issue thread.
In the thread they aren't really needed and feel kinda out of place.