### PR TITLE
Added password mismatch warning for intro screen

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/IntroScreenActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/IntroScreenActivity.java
@@ -275,6 +275,7 @@ public class IntroScreenActivity extends IntroActivity {
         private String lengthWarning = "";
         private String noPasswordWarning = "";
         private String confirmPasswordWarning = "";
+        private String passwordMismatchWarning = "";
 
         private TextView desc = null;
         private Spinner selection = null;
@@ -432,6 +433,7 @@ public class IntroScreenActivity extends IntroActivity {
                     lengthWarning = getString(R.string.settings_label_short_password, minLength);
                     noPasswordWarning = getString(R.string.intro_slide3_warn_no_password);
                     confirmPasswordWarning = getString(R.string.intro_slide3_warn_confirm_password);
+                    passwordMismatchWarning = getString(R.string.intro_slide3_warn_password_mismatch);
 
                     focusOnPasswordInput();
                 }
@@ -458,6 +460,7 @@ public class IntroScreenActivity extends IntroActivity {
                     lengthWarning = getString(R.string.settings_label_short_pin, minLength);
                     noPasswordWarning = getString(R.string.intro_slide3_warn_no_pin);
                     confirmPasswordWarning = getString(R.string.intro_slide3_warn_confirm_pin);
+                    passwordMismatchWarning = getString(R.string.intro_slide3_warn_pin_mismatch);
 
                     focusOnPasswordInput();
                 }
@@ -506,6 +509,9 @@ public class IntroScreenActivity extends IntroActivity {
                         if (! confirm.isEmpty() && confirm.equals(password)) {
                             hideWarning();
                             return true;
+                        } else if (! confirm.isEmpty() && ! confirm.equals(password)) {
+                            updateWarning(passwordMismatchWarning);
+                            return false;
                         } else {
                             updateWarning(confirmPasswordWarning);
                             return false;

--- a/app/src/main/res/values/strings_intro.xml
+++ b/app/src/main/res/values/strings_intro.xml
@@ -33,7 +33,9 @@
     <string name="intro_slide3_warn_no_password">Please set a password to continue!</string>
     <string name="intro_slide3_warn_no_pin">Please set a PIN to continue!</string>
     <string name="intro_slide3_warn_confirm_password">Please confirm your password to continue!</string>
+    <string name="intro_slide3_warn_password_mismatch">Passwords must match!</string>
     <string name="intro_slide3_warn_confirm_pin">Please confirm your PIN to continue!</string>
+    <string name="intro_slide3_warn_pin_mismatch">Pins must match!</string>
 
     <string name="intro_slide4_title">Finished</string>
     <string name="intro_slide4_desc">Your settings have been saved, you are now all set to use


### PR DESCRIPTION
I noticed that on the password initialization screen you get the same error message whether you have an empty confirm field or a mismatched confirm field, which appears like the app doesn't register the confirm field has text. This could be confusing to users if they accidentally hit an extra key and don't realize that there's an extra character in the confirm field. I propose adding an additional warning message for the case where the user has entered a confirm value, but it doesn't match the password value. 