### PR TITLE
fix QR code not found in image file

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,12 +72,7 @@ dependencies {
     implementation "com.github.aakira:expandable-layout:1.6.0"
     implementation "com.heinrichreimersoftware:material-intro:2.0.0"
     implementation("com.journeyapps:zxing-android-embedded:4.1.0") { transitive = false }
-    implementation('com.google.zxing:core') {
-        version {
-            strictly '[3.3, 3.4[' // Keep pinned below 3.4 to support SDK versions below 24
-            prefer '3.3.0'
-        }
-    }
+    implementation('com.google.zxing:core:3.4.1')
     implementation "com.vanniktech:vntnumberpickerpreference:1.0.0"
     implementation "me.zhanghai.android.materialprogressbar:library:1.6.1"
     implementation "org.sufficientlysecure:openpgp-api:12.0"

--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/ScanQRCodeFromFile.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/ScanQRCodeFromFile.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (C) 2017-2020 Jakob Nixdorf
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
 package org.shadowice.flocke.andotp.Utilities;
 
 import android.content.Context;


### PR DESCRIPTION
Try decoding the image multiple times with different decoding hints and update dependency _ZXing_ to version 3.4.1. to FIX #790.

Note: Although the documentation says that from `com.google.zxing:core` version 3.4.0 and later Java 8, which requires targeting API level 24 or later, is required, using Java 8 desugaring is a possible solution. For details see: https://developer.android.com/studio/write/java8-support

Java 8 desugaring was enabled for andOTP with #544 (commit df6c7cd41625dc714b73b727c55a34ae0c96839a) and is available since 0.8.0.

I tested this with the Android emulator on API Level 22 and 30.