### PR TITLE
Add mac2fa to PC apps section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ key, which renders them useless.
  * [OpenPGP](https://openpgp.org/): OpenPGP can be used to easily decrypt the **OpenPGP-encrypted backups** on your PC.
  * [WebDecrypt](https://flocke.shadowice.org/andOTP/decrypt/): JavaScript-based decryption of the **new password-protected backup format** in the browser ([source code](https://github.com/andOTP/WebDecrypt)).
  * [andOTP-decrypt](https://github.com/asmw/andOTP-decrypt): Python script written by @asmw to decrypt the **old and new password-protected backup format** on your PC.
+ * [mac2fa](https://github.com/lorenzo2897/mac2fa): Electron app for macOS that lives in your system tray and generates OTPs from an encrypted backup file.
 
 ### Automatic backups:
 


### PR DESCRIPTION
Proposing an addition to the "opening backups on your PC" section with an Electron-based app for macOS desktop.