### PR TITLE
New feature to read auth password from NFC Tag

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,11 @@
                 <action android:name="org.shadowice.flocke.andotp.intent.ENTER_DETAILS" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/plain" />
+            </intent-filter>
             <meta-data android:name="android.app.shortcuts"
                        android:resource="@xml/shortcuts" />
         </activity>

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
@@ -105,6 +105,9 @@ public class AuthenticateActivity extends BackgroundTaskActivity<AuthenticationT
             });
 
         getWindow().setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+
+        String pass = getIntent().getStringExtra(Constants.EXTRA_AUTH_PLAIN_PASSWORD);
+        if (pass != null) { startAuthTask(pass); }
     }
 
     private void initToolbar() {

--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/Constants.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/Constants.java
@@ -92,6 +92,7 @@ public class Constants {
     public final static String EXTRA_AUTH_PASSWORD_KEY              = "password_key";
     public final static String EXTRA_AUTH_NEW_ENCRYPTION            = "new_encryption";
     public final static String EXTRA_AUTH_MESSAGE                   = "message";
+    public final static String EXTRA_AUTH_PLAIN_PASSWORD            = "plain_password";
 
     public final static String EXTRA_BACKUP_ENCRYPTION_KEY          = "encryption_key";
 


### PR DESCRIPTION
Hey, I've never contributed to any opensource project, but I found yours and liked. I have no idea if thats proper way to do this. 

There was only one problem to me with andOTP. Since I use OTP quite often, entering password every time is pain for me. So I decided to add simple feature to read password from NFC tag, where you can store plain text password and just scan it to authorize. I have NFC ring on my finger where I can store password, and scan it easly.

You can use any app and any writable tag to write text type data into, and then when you scan it, it opens andOTP and smoothly authorizes. For me it works great. It would be nice, if you would put this on your app.