### PR TITLE
Fix NPE when issuer was not given

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/View/EntryViewHolder.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/View/EntryViewHolder.java
@@ -251,7 +251,7 @@ public class EntryViewHolder extends RecyclerView.ViewHolder
 
         int thumbnailSize = settings.getThumbnailSize();
         if(settings.getThumbnailVisible()) {
-            thumbnailImg.setImageBitmap(EntryThumbnail.getThumbnailGraphic(context, entry.getIssuer(), entry.getLabel(), thumbnailSize, entry.getThumbnail()));
+            thumbnailImg.setImageBitmap(EntryThumbnail.getThumbnailGraphic(context, TextUtils.isEmpty(issuerText) ? "": issuerText, entry.getLabel(), thumbnailSize, entry.getThumbnail()));
         }
 
         if (entry.isTimeBased() && (entry.hasNonDefaultPeriod() || settings.isShowIndividualTimeoutsEnabled())) {


### PR DESCRIPTION
When scanning an image, the URL encoded in the QR code might not contain an issuer, as it is only "STRONGLY RECOMMENDED" according to the [Key Uri Format](https://github.com/google/google-authenticator/wiki/Key-Uri-Format).