### PR TITLE
Added go-andotp for opening backups on PC

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ key, which renders them useless.
  * [WebDecrypt](https://flocke.shadowice.org/andOTP/decrypt/): JavaScript-based decryption of the **new password-protected backup format** in the browser ([source code](https://github.com/andOTP/WebDecrypt)).
  * [andOTP-decrypt](https://github.com/asmw/andOTP-decrypt): Python script written by @asmw to decrypt the **old and new password-protected backup format** on your PC.
  * [mac2fa](https://github.com/lorenzo2897/mac2fa): Electron app for macOS that lives in your system tray and generates OTPs from an encrypted backup file.
+ * [go-andotp](https://github.com/grijul/go-andotp): CLI Program written in go to encrypt/decrypt andOTP files on your PC. Decrypted files can be encrypted and imported back to andOTP.
 
 ### Automatic backups:
 


### PR DESCRIPTION
This PR adds go-andotp (https://github.com/grijul/go-andotp) as an option to open andOTP decrypted files on PC.

go-andotp supports:
- Encryption of JSON files (which can then be imported to andOTP)
- Decryption of JSON files.