### PR TITLE
(FIX #814) allow password reveal only before start typing

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/AuthenticateActivity.java
@@ -32,6 +32,7 @@ import androidx.appcompat.widget.Toolbar;
 
 import android.text.Editable;
 import android.text.InputType;
+import android.text.TextWatcher;
 import android.text.method.PasswordTransformationMethod;
 import android.view.KeyEvent;
 import android.view.View;
@@ -148,8 +149,33 @@ public class AuthenticateActivity extends BackgroundTaskActivity<AuthenticationT
                 ? (InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD)
                 : (InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_PASSWORD);
         passwordInput.setInputType(inputType);
-        passwordInput.setTransformationMethod(new PasswordTransformationMethod());
+        passwordInput.setTransformationMethod(PasswordTransformationMethod.getInstance());
         passwordInput.setOnEditorActionListener(this);
+        passwordInput.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                if (
+                        passwordInput.getTransformationMethod() == PasswordTransformationMethod.getInstance() &&
+                                passwordLayout.getEndIconMode() == TextInputLayout.END_ICON_PASSWORD_TOGGLE &&
+                                s.length() > 0
+                ) {
+                    passwordLayout.setEndIconMode(TextInputLayout.END_ICON_NONE);
+                } else if (
+                        passwordLayout.getEndIconMode() == TextInputLayout.END_ICON_NONE &&
+                                s.length() == 0
+                ) {
+                    passwordLayout.setEndIconMode(TextInputLayout.END_ICON_PASSWORD_TOGGLE);
+                }
+            }
+        });
     }
 
     private void initUnlockViews(View v) {


### PR DESCRIPTION
This small commit should fix issue #814 by disabling the password reveal button if some input on the password input has already been made without the 'reveal password' toggle active.

If the password toggle was set to be enabled before starting to enter the password, it stays enabled and the password can be read.
When disabling the toggle with a password already entered, the toggle button disappears.
It only returns when the password field is empty again.

This should be an easy-to-understand solution for the end user while still providing the security benefit mentioned in #814.