### PR TITLE
Fixed: Crash when filling password using Magikeyboard from KeePassDX (#866)

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EditorActionHelper.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EditorActionHelper.java
@@ -13,7 +13,10 @@ public class EditorActionHelper {
     private EditorActionHelper() { /* not allowed */ }
 
     public static boolean isActionDoneOrKeyboardEnter(int actionId, KeyEvent event) {
-        boolean isKeyboardEnterEvent = event.getAction() == ACTION_DOWN && (event.getKeyCode() == KEYCODE_ENTER || event.getKeyCode() == KEYCODE_NUMPAD_ENTER);
+        boolean isKeyboardEnterEvent = false;
+        if (event != null) {
+            isKeyboardEnterEvent = event.getAction() == ACTION_DOWN && (event.getKeyCode() == KEYCODE_ENTER || event.getKeyCode() == KEYCODE_NUMPAD_ENTER);
+        }
 
         return actionId == EditorInfo.IME_ACTION_DONE || isKeyboardEnterEvent;
     }

--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EditorActionHelper.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EditorActionHelper.java
@@ -13,8 +13,9 @@ public class EditorActionHelper {
     private EditorActionHelper() { /* not allowed */ }
 
     public static boolean isActionDoneOrKeyboardEnter(int actionId, KeyEvent event) {
-        return actionId == EditorInfo.IME_ACTION_DONE
-                || event.getAction() == ACTION_DOWN && (event.getKeyCode() == KEYCODE_ENTER || event.getKeyCode() == KEYCODE_NUMPAD_ENTER);
+        boolean isKeyboardEnterEvent = event.getAction() == ACTION_DOWN && (event.getKeyCode() == KEYCODE_ENTER || event.getKeyCode() == KEYCODE_NUMPAD_ENTER);
+
+        return actionId == EditorInfo.IME_ACTION_DONE || isKeyboardEnterEvent;
     }
 
     public static boolean isActionUpKeyboardEnter(KeyEvent event) {


### PR DESCRIPTION
With this branch, the app no longer crashes when filling the password using the Magikeyboard from KeePassDX.

This pull request resolves #866, and steps to reproduce/test the behaviour can be found in the bug report.