### PR TITLE
Fix navigation bar icons legibility for API 26 and below

### DIFF
--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -2,6 +2,7 @@
     <!-- Light application theme -->
     <style name="AppTheme" parent="AppBaseTheme">
         <item name="android:windowLightNavigationBar">true</item>
+        <item name="navigationBarColor">?android:attr/colorBackground</item>
     </style>
 
     <style name="AppTheme.Dark" parent="AppBaseTheme.Dark">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -25,7 +25,7 @@
         <item name="colorAccent">@color/colorAccent</item>
 
         <item name="windowBackground">?android:attr/colorBackground</item>
-        <item name="navigationBarColor">?android:attr/colorBackground</item>
+        <item name="navigationBarColor">@color/black</item>
 
         <item name="colorGithub">@color/github_dark</item>
         <item name="thumbnailBackground">@android:color/transparent</item>


### PR DESCRIPTION
This fixes #507

It seems that devices running Android 8.0 (API 26) and below draw the navigation bar buttons using white or almost white color. At least, as mentioned in the linked issue, vanilla Android, Lineage OS, and EMUI do that.

To my understanding, the Android navigation bar wasn't supposed to have a light color until Android 8.1 (API 27) where a theme attribute `android:lightNavigationBar` was introduced, which allows to explicitly tell the system that we want the buttons to be drawn using a dark color.

So I propose:

- For devices with API 26 and below change the navigation bar color to black so that white buttons become legible.
- For devices with API 27 and above leave the navigation bar color as is.

All of the changes only affect the light theme.

Here is how the navigation bar would look before and after the changes on devices with API 26 and below:

![Nav_bar_old](https://user-images.githubusercontent.com/20794900/140088107-47583c0d-76bb-4082-a59a-5eb1d0a87282.jpg)

![Nav_bar_new](https://user-images.githubusercontent.com/20794900/140088774-54fb7f09-52ff-4747-8a2c-fdde691ed94b.jpg)

