### PR TITLE
Increase number of PBKDF2 iterations

### DIFF
--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/BackupHelper.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/BackupHelper.java
@@ -104,7 +104,7 @@ public class BackupHelper {
         boolean success;
 
         try {
-            int iter = EncryptionHelper.generateRandomIterations();
+            int iter = Constants.PBKDF2_BACKUP_ITERATIONS;
             byte[] salt = EncryptionHelper.generateRandom(Constants.ENCRYPTION_IV_LENGTH);
 
             SecretKey key = EncryptionHelper.generateSymmetricKeyPBKDF2(password, iter, salt);

--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/Constants.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/Constants.java
@@ -121,8 +121,7 @@ public class Constants {
     final static int PBKDF2_BENCHMARK_ITERATIONS    = 50000;
 
     // PBKDF2 settings for backups
-    final static int PBKDF2_MIN_BACKUP_ITERATIONS   = 140000;
-    final static int PBKDF2_MAX_BACKUP_ITERATIONS   = 160000;
+    final static int PBKDF2_BACKUP_ITERATIONS       = 750000;
 
     // Authentication
     public final static int AUTH_MIN_PIN_LENGTH        = 4;

--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EncryptionHelper.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/EncryptionHelper.java
@@ -127,11 +127,6 @@ public class EncryptionHelper {
         }
     }
 
-    public static int generateRandomIterations() {
-        Random rand = new Random();
-        return rand.nextInt((Constants.PBKDF2_MAX_BACKUP_ITERATIONS - Constants.PBKDF2_MIN_BACKUP_ITERATIONS) + 1) + Constants.PBKDF2_MIN_BACKUP_ITERATIONS;
-    }
-
     public static byte[] generateRandom(int length) {
         final byte[] raw = new byte[length];
         new SecureRandom().nextBytes(raw);


### PR DESCRIPTION
This solves issue #975 by rasing the number of iterations to be more
than 720,000. Also for the sake of simplicity all new backups will
use the same number of iterations insead of a random number in a
small range. This change is backwards compatable with the old backups
that had a random iteration count.